### PR TITLE
Remove unnecessary "sign_data" endpoint

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -119,16 +119,6 @@ class App {
       });
     });
 
-    this.express.post('/api/sign_data', (req, res, next) => {
-      authHandler.getSignData(req.body.msg, req.body.pub_key)
-        .then((response: any) => {
-          res.send(response);
-        })
-        .catch((err) => {
-          next(err);
-        })
-    });
-
     this.express.use(logger.after);
   }
 }

--- a/src/handlers/auth_handler.ts
+++ b/src/handlers/auth_handler.ts
@@ -1,23 +1,6 @@
 import axios from "axios";
 
 export class AuthHandler {
-  getSignData = (msgHex: string, pubKey: string) => {
-    return new Promise((resolve: Function, reject: Function) => {
-      const rest = (process.env.BC_REST || 'http://localhost:1317');
-      axios.post(rest + '/txs/sign_data', {msg: msgHex, pub_key: pubKey})
-        .then((response) => {
-          if (response.status == 200) {
-            resolve(response.data);
-          } else {
-            reject(response.statusText);
-          }
-        })
-        .catch((error) => {
-          reject(error.response.data.error);
-        });
-    })
-  }
-
   decodeTx = (txData: string) => {
     return new Promise((resolve: Function, reject: Function) => {
       let rest = (process.env.BC_REST || 'localhost:1317');


### PR DESCRIPTION
This endpoint is doing nothing except forwarding the request to the blokchain endpoint with the same name. There seems to be nothing preventing clients from communicating with the blockchain directly, so this is just noise here.

Thoughts?

I'd also say that if this makes sense to you in principle, we should do the same to other forward-only endpoints.