### PR TITLE
Added functionality to update a project's data

### DIFF
--- a/src/sync_handlers/txn_handler.ts
+++ b/src/sync_handlers/txn_handler.ts
@@ -17,6 +17,7 @@ export class TransactionHandler {
     CAPTURE_CLAIM: "project/CreateClaim",
     CLAIM_UPDATE: "project/CreateEvaluation",
     PROJECT_STATUS_UPDATE: "project/UpdateProjectStatus",
+    PROJECT_DOC_UPDATE: "project/UpdateProjectDoc",
     ADD_CREDENTIAL: "did/AddCredential"
   });
   AGENT_TYPE = Object.freeze({SERVICE: 'SA', EVALUATOR: 'EA', INVESTOR: 'IA'});
@@ -129,6 +130,8 @@ export class TransactionHandler {
         return this.didSyncHandler.addCredential(msgVal.credential.claim.id, credential);
       case this.TXN_TYPE.PROJECT_STATUS_UPDATE:
         return this.projectSyncHandler.updateProjectStatus(msgVal.data.status, msgVal.projectDid);
+      case this.TXN_TYPE.PROJECT_DOC_UPDATE:
+        return this.projectSyncHandler.updateProjectDoc(msgVal.data, msgVal.projectDid);
     }
   }
 


### PR DESCRIPTION
Following [changes to ixo-cellnode](https://github.com/ixofoundation/ixo-cellnode/pull/85) which add the functionality of updating an existing project's `Data` field, the below changes were made to ixo-blocksync:
- a new transaction type for updating project doc was added
- a function `updateProjectDoc` was added, which finds the existing project in the Project DB, and replaces the project's `Data` field, while keeping some of the old project's fields (that might not have been included in the new data) intact.