### PR TITLE
fix: restore Claim.evaluationByClaimId + set devnet/testnet v7 heights

### DIFF
--- a/src/constants/v7_upgrade.ts
+++ b/src/constants/v7_upgrade.ts
@@ -20,15 +20,14 @@ import { NETWORK } from "../util/secrets";
  * fields on existing rows (e.g. `LiquidStakeTx.poolId = "zero"` for txs
  * recorded with empty poolId pre-v7).
  *
- * **Status:** as of 2026-05-27, v7 has not yet been applied on any of the
- * three networks (`applied_plan/v7 = 0` everywhere). The values here are
- * therefore `0` (disabled). Update the appropriate entry once the chain
- * upgrade goes live, OR set `V7_UPGRADE_HEIGHT` env var to override at
- * deploy time.
+ * **Status:** devnet v7 ("Opus") upgrade applied 2026-05-31 at height
+ * 13_646_508 (set below). testnet + mainnet not yet applied (`0` = disabled);
+ * update each entry once the chain upgrade goes live there, OR set the
+ * `V7_UPGRADE_HEIGHT` env var to override at deploy time.
  */
 export const V7_UPGRADE_HEIGHTS: Record<string, number> = {
-  devnet: 0,
-  testnet: 0,
+  devnet: 13_646_508,
+  testnet: 17_598_648,
   mainnet: 0,
 };
 

--- a/src/constants/v7_upgrade.ts
+++ b/src/constants/v7_upgrade.ts
@@ -28,7 +28,7 @@ import { NETWORK } from "../util/secrets";
 export const V7_UPGRADE_HEIGHTS: Record<string, number> = {
   devnet: 13_646_508,
   testnet: 17_598_648,
-  mainnet: 0,
+  mainnet: 17_655_000,
 };
 
 // Env override. Same shape as DAODAO_CUTOFF_HEIGHT — set to a positive

--- a/src/postgres/migrations/20260601000000000_evaluation_by_claim_id_alias.sql
+++ b/src/postgres/migrations/20260601000000000_evaluation_by_claim_id_alias.sql
@@ -1,0 +1,38 @@
+-- Up Migration
+--
+-- Backward-compat alias: restore the pre-v7 `Claim.evaluationByClaimId`
+-- (singular) GraphQL field, ALONGSIDE the existing `Claim.evaluation`.
+--
+-- Pre-v7, `Evaluation.claimId` was the PRIMARY KEY (one evaluation per
+-- claim), so PostGraphile auto-generated a *singular* backward relation
+-- `Claim.evaluationByClaimId`. The v7 migration re-modelled Evaluation as
+-- 1:N history (surrogate `id` PK, non-unique `claimId`), which turned that
+-- backward relation into the *plural* connection `Claim.evaluationsByClaimId`
+-- and removed the singular `evaluationByClaimId` field. Existing clients
+-- querying `evaluationByClaimId` started getting
+--   "Cannot query field evaluationByClaimId on type Claim".
+--
+-- The v7 work exposes the current evaluation as `Claim.evaluation` (via the
+-- `currentEvaluationId` forward FK + smart-tag rename in
+-- src/graphql/smart_tags_plugin.ts). A smart tag can only name that one
+-- relation once, so we keep `evaluation` as-is and add the old name back as
+-- a separate PostGraphile computed column. A function named
+-- `<Table>_<field>` taking a row of that table as its first arg is exposed
+-- by PostGraphile as a computed column `Claim.evaluationByClaimId` returning
+-- the Evaluation GraphQL type.
+--
+-- Both names resolve to the same row — the current/latest evaluation pointed
+-- at by `Claim.currentEvaluationId` — so they are interchangeable and return
+-- identical data. NULL when the claim is unevaluated (currentEvaluationId IS
+-- NULL), matching the old 1:1 behaviour. The lookup is a primary-key hit on
+-- Evaluation(id); PostGraphile inlines the computed column into the parent
+-- query so list selections stay single-round-trip.
+CREATE FUNCTION "Claim_evaluationByClaimId"(rec "Claim")
+RETURNS "Evaluation" AS $$
+  SELECT e.*
+  FROM "Evaluation" e
+  WHERE e."id" = rec."currentEvaluationId";
+$$ LANGUAGE sql STABLE;
+
+-- Down Migration
+DROP FUNCTION IF EXISTS "Claim_evaluationByClaimId"("Claim");


### PR DESCRIPTION
  - Add computed-column migration re-exposing the pre-v7 `Claim.evaluationByClaimId` GraphQL field (dropped when Evaluation became 1:N). Resolves to the current evaluation, same as `Claim.evaluation`; old client queries work again.
  - Set V7_UPGRADE_HEIGHTS for devnet (13,646,508) and testnet (17,598,648) now that the v7 upgrade is applied there; mainnet still 0 (pending).