### PR TITLE
feat: incremental TokenBalance table for fast per-address holdings

### DIFF
--- a/src/postgres/migrations/20260617000000000_token_balance.sql
+++ b/src/postgres/migrations/20260617000000000_token_balance.sql
@@ -1,0 +1,62 @@
+-- Up Migration
+--
+-- Running per-(address, tokenId) token balances.
+--
+-- "TokenTransaction" is an append-only ledger. Reading an address's holdings
+-- previously meant scanning + SUM-ing every transaction that address ever
+-- touched (see getAccountTokensSql / getAccountTokens in src/postgres/token.ts
+-- and src/handlers/token_handler.ts) — an O(transactions) cost that grows
+-- without bound as the ledger does, whether done via a SQL CTE or PostGraphile
+-- aggregates.
+--
+-- This table keeps a materialised net balance that is updated incrementally in
+-- the same transaction that writes each TokenTransaction row (see
+-- createTokenTransaction in src/postgres/token.ts). Reading an address's full
+-- holdings becomes a single index lookup whose cost is O(distinct tokens held
+-- by that address), independent of total ledger size.
+--
+-- Balance semantics mirror the ledger: a row's `to` is credited and its `from`
+-- is debited. `from`/`to` are EMPTY STRINGS (not NULL) for mints/retires
+-- respectively — getWasmAttr() returns "" when an attribute is absent — so the
+-- empty side is skipped. Self-transfers (from = to) are already filtered out
+-- before a TokenTransaction is ever written, so there is no double-count.
+--
+-- A row exists iff the address currently holds the token: balances that net to
+-- zero are deleted (see applyTokenBalanceDelta in src/postgres/token.ts) and
+-- excluded from the backfill, so clients never need to filter zeros.
+--
+-- `amount` is BIGINT to match TokenTransaction.amount. A single address's
+-- balance for a token is bounded by that token's total supply, which the chain
+-- itself tracks as a uint64 (TokenClass.supply / .cap are BIGINT), so a balance
+-- cannot exceed BIGINT range by construction.
+CREATE TABLE "TokenBalance" (
+    "address" TEXT NOT NULL,
+    "tokenId" TEXT NOT NULL,
+    "amount"  BIGINT NOT NULL DEFAULT 0,
+
+    CONSTRAINT "TokenBalance_pkey" PRIMARY KEY ("address", "tokenId"),
+    CONSTRAINT "TokenBalance_tokenId_fkey" FOREIGN KEY ("tokenId")
+        REFERENCES "Token"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- No separate index on ("address") is needed: the primary-key btree leads with
+-- "address", so `WHERE "address" = $1` (the only read pattern) is already
+-- served by the PK index. Adding one would only add write overhead.
+
+-- Backfill from the existing ledger. One pass that explodes each transaction
+-- into a (+amount to recipient) and (-amount from sender) delta, excluding the
+-- empty side, then nets them per (address, tokenId).
+INSERT INTO "TokenBalance" ("address", "tokenId", "amount")
+SELECT addr, "tokenId", SUM(delta)::bigint
+FROM (
+    SELECT "to"   AS addr, "tokenId",  "amount" AS delta
+      FROM "TokenTransaction" WHERE "to"   <> ''
+    UNION ALL
+    SELECT "from" AS addr, "tokenId", -"amount" AS delta
+      FROM "TokenTransaction" WHERE "from" <> ''
+) deltas
+GROUP BY addr, "tokenId"
+HAVING SUM(delta) <> 0;
+
+-- Down Migration
+DROP TABLE IF EXISTS "TokenBalance";

--- a/src/postgres/token.ts
+++ b/src/postgres/token.ts
@@ -18,10 +18,52 @@ export type TokenTransaction = {
 const createTokenTransactionSql = `
 INSERT INTO "TokenTransaction" ("from", "to", amount, "tokenId") VALUES ($1, $2, $3, $4);
 `;
+
+// Accumulate a signed delta onto an address's running balance for a token, and
+// return the resulting balance. Inserts the row on first sight, otherwise adds
+// to the existing balance. Runs on the same connection (currentPool) as the
+// TokenTransaction insert, so the ledger row and the balance update commit
+// atomically within the per-block transaction.
+const upsertTokenBalanceSql = `
+INSERT INTO "TokenBalance" ("address", "tokenId", "amount") VALUES ($1, $2, $3)
+ON CONFLICT ("address", "tokenId")
+DO UPDATE SET "amount" = "TokenBalance"."amount" + EXCLUDED."amount"
+RETURNING "amount";
+`;
+
+const deleteTokenBalanceSql = `
+DELETE FROM "TokenBalance" WHERE "address" = $1 AND "tokenId" = $2;
+`;
+
+// A row in "TokenBalance" means "this address currently holds this token", so a
+// balance that nets to zero is removed rather than kept around. The delete only
+// fires on the rare drain-to-zero (detected via RETURNING), so the common
+// transfer path stays a single statement.
+const applyTokenBalanceDelta = async (
+  address: string,
+  tokenId: string,
+  delta: bigint
+): Promise<void> => {
+  const res = await dbQuery(upsertTokenBalanceSql, [address, tokenId, delta]);
+  if (BigInt(res.rows[0].amount) === 0n) {
+    await dbQuery(deleteTokenBalanceSql, [address, tokenId]);
+  }
+};
+
 export const createTokenTransaction = async (
   t: TokenTransaction
 ): Promise<void> => {
   await dbQuery(createTokenTransactionSql, [t.from, t.to, t.amount, t.tokenId]);
+
+  // Keep "TokenBalance" in sync with the ledger: credit the recipient, debit
+  // the sender. `from`/`to` are empty strings for mints/retires, so the empty
+  // side is skipped. Self-transfers never reach here (filtered upstream).
+  if (t.to) {
+    await applyTokenBalanceDelta(t.to, t.tokenId, t.amount);
+  }
+  if (t.from) {
+    await applyTokenBalanceDelta(t.from, t.tokenId, -t.amount);
+  }
 };
 
 const getTokenClassContractAddressSql = `


### PR DESCRIPTION
## What
Adds a `TokenBalance` table that maintains a running net balance per `(address, tokenId)`, updated incrementally in the same transaction that writes each `TokenTransaction`.

## Why
`TokenTransaction` is an append-only ledger. Reading an address's holdings previously meant scanning + `SUM`-ing every transaction it ever touched (via CTE or PostGraphile aggregates) — an O(transactions) cost that grows without bound.

With `TokenBalance`, clients read full holdings in **one indexed query**, cost O(distinct tokens held), flat regardless of ledger size:

```graphql
{ allTokenBalances(condition: { address: "ixo1..." }) {
    nodes { tokenId amount tokenByTokenId { name collection } } } }
```

## How
- Migration `20260617000000000_token_balance.sql`: table (PK `(address, tokenId)`, FK → `Token`) + one-pass backfill from the ledger (`HAVING SUM(delta) <> 0`).
- `createTokenTransaction` upserts the balance: credit `to`, debit `from`, skipping the empty side (mints have empty `from`, retires empty `to`). Runs on the per-block transaction connection → atomic & crash-safe.
- Zero-balance rows are deleted (only fires on drain-to-zero via `RETURNING`), so a row exists **iff** the address holds the token — no zero-filter needed on read. Negative balances are kept visible to surface any indexing bug.

## Notes
- `amount` is BIGINT, matching `TokenTransaction.amount`; bounded by token supply (chain-capped uint64).
- Run `npm run migrate:up` to create + backfill; GraphQL field appears on next boot.

Authored by: Michael Pretorius <michael@ixo.world>