### PR TITLE
perf: back token resolvers with TokenBalance (minted/retired) instead of ledger scans

### DIFF
--- a/src/graphql/token.ts
+++ b/src/graphql/token.ts
@@ -1,18 +1,52 @@
 import { makeExtendSchemaPlugin, gql } from "graphile-utils";
 import * as TokenHandler from "../handlers/token_handler";
+import {
+  AccountTokenBalance,
+  getAccountTokenBalancesBatch,
+} from "../postgres/token";
 import DataLoader from "dataloader";
 
 export type GetAccountTransactionsLoader = ReturnType<
   typeof createGetAccountTransactionsLoader
 >;
+
+// Per-request loader over per-(address, tokenId) balances. Keys are
+// "address-name" (see createGetAccountTransactionsKey). Addresses never contain
+// "-", so we split on the first one. All keys requested in the same tick are
+// collapsed into one DB query per distinct name filter (`address = ANY(...)`),
+// which turns the entity / collection fan-out resolvers from N round-trips into
+// one.
 export const createGetAccountTransactionsLoader = () => {
-  return new DataLoader(async (keys: string[]) => {
-    return keys.map(async (key) => {
-      const [id, name] = key.split("-");
-      const actualName = name === "NULL" ? undefined : name;
-      return await TokenHandler.getAccountTransactions(id, actualName);
-    });
-  });
+  return new DataLoader<string, AccountTokenBalance[]>(
+    async (keys: readonly string[]) => {
+      // group requested addresses by their name filter
+      const byName = new Map<string | null, Set<string>>();
+      for (const key of keys) {
+        const sep = key.indexOf("-");
+        const address = key.slice(0, sep);
+        const rawName = key.slice(sep + 1);
+        const name = rawName === "NULL" ? null : rawName;
+        if (!byName.has(name)) byName.set(name, new Set());
+        byName.get(name)!.add(address);
+      }
+
+      // one query per distinct name filter, then index rows by address
+      const rowsByKey = new Map<string, AccountTokenBalance[]>();
+      await Promise.all(
+        [...byName.entries()].map(async ([name, addresses]) => {
+          const rows = await getAccountTokenBalancesBatch([...addresses], name);
+          for (const row of rows) {
+            const key = `${row.address}-${name ?? "NULL"}`;
+            const list = rowsByKey.get(key);
+            if (list) list.push(row);
+            else rowsByKey.set(key, [row]);
+          }
+        })
+      );
+
+      return keys.map((key) => rowsByKey.get(key) ?? []);
+    }
+  );
 };
 
 export const TokenPlugin = makeExtendSchemaPlugin((build) => {

--- a/src/handlers/token_handler.ts
+++ b/src/handlers/token_handler.ts
@@ -4,8 +4,8 @@ import {
   getEntityDeviceAccounts,
 } from "../postgres/entity";
 import {
+  getAccountTokenBalances,
   getAccountTokensFromDb,
-  getTokenClass,
   getTokenRetiredAmountSUM,
   getTokenTransaction,
 } from "../postgres/token";
@@ -102,57 +102,32 @@ export const getAccountTokens = async (
   transactionLoader?: GetAccountTransactionsLoader,
   allEntityRetired?: boolean
 ) => {
-  let tokenTransactions = transactionLoader
+  // Read pre-aggregated per-(address, tokenId) balances directly from
+  // "TokenBalance" (one indexed lookup) instead of scanning + folding the whole
+  // transaction ledger. The loader batches multiple addresses (entity /
+  // collection fan-outs) into a single query.
+  const balances = transactionLoader
     ? await transactionLoader.load(
         createGetAccountTransactionsKey(address, name)
       )
-    : await getAccountTransactions(address, name);
+    : await getAccountTokenBalances(address, name);
 
   const tokens = {};
-  for (const curr of tokenTransactions) {
+  for (const curr of balances) {
     if (!tokens[curr.name]) {
-      const tokenClass = await getTokenClass(curr.name);
       tokens[curr.name] = {
-        contractAddress: tokenClass?.contractAddress,
-        description: tokenClass?.description,
-        image: tokenClass?.image,
+        contractAddress: curr.contractAddress,
+        description: curr.description,
+        image: curr.image,
         tokens: {},
       };
     }
-
-    // if from address is same it means it is an outgoing transaction in relation to the address
-    if (curr.from === address) {
-      if (tokens[curr.name].tokens[curr.tokenId]) {
-        tokens[curr.name].tokens[curr.tokenId].amount -= Number(curr.amount);
-      } else {
-        tokens[curr.name].tokens[curr.tokenId] = {
-          collection: curr.collection,
-          amount: -Number(curr.amount),
-          minted: 0,
-          retired: 0,
-        };
-      }
-      // if no to it means was retired from this address
-      if (!curr.to) {
-        tokens[curr.name].tokens[curr.tokenId].retired += Number(curr.amount);
-      }
-      // if to address is same it means it is an incoming transaction in relation to the address
-    } else {
-      if (tokens[curr.name].tokens[curr.tokenId]) {
-        tokens[curr.name].tokens[curr.tokenId].amount += Number(curr.amount);
-      } else {
-        tokens[curr.name].tokens[curr.tokenId] = {
-          collection: curr.collection,
-          amount: Number(curr.amount),
-          minted: 0,
-          retired: 0,
-        };
-      }
-      // if no from it means was minted to address
-      if (!curr.from) {
-        tokens[curr.name].tokens[curr.tokenId].minted += Number(curr.amount);
-      }
-    }
+    tokens[curr.name].tokens[curr.tokenId] = {
+      collection: curr.collection,
+      amount: Number(curr.amount),
+      minted: Number(curr.minted),
+      retired: Number(curr.retired),
+    };
   }
 
   // if allEntityRetired is true then for retired values get all retired ever from

--- a/src/postgres/migrations/20260618000000000_token_balance_minted_retired.sql
+++ b/src/postgres/migrations/20260618000000000_token_balance_minted_retired.sql
@@ -1,0 +1,59 @@
+-- Up Migration
+--
+-- Extend "TokenBalance" with cumulative `minted` and `retired` columns so it can
+-- back the full getAccountTokens primitive (per (address, tokenId): amount,
+-- minted, retired) — not just the net balance. This lets the custom token
+-- resolvers read a single indexed row per held token instead of scanning and
+-- folding the whole TokenTransaction ledger in JS.
+--
+--   minted  = total ever minted TO this address for this token
+--             (credit side where "from" is empty)
+--   retired = total ever retired BY this address for this token
+--             (debit side where "to" is empty)
+--
+-- Both are monotonic (only ever increase), mirroring token_handler.ts.
+--
+-- The original "TokenBalance" deleted any row whose net amount hit zero. With
+-- minted/retired tracked, a row must survive while EITHER is non-zero (e.g. an
+-- address that minted then transferred everything away: amount = 0 but
+-- minted > 0). That changes which rows should exist, and the live table was
+-- populated under the old amount-only rule, so we rebuild it from the ledger
+-- rather than ALTER + patch.
+
+ALTER TABLE "TokenBalance"
+    ADD COLUMN "minted"  BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN "retired" BIGINT NOT NULL DEFAULT 0;
+
+-- Rebuild from the append-only ledger. Each transaction contributes a credit
+-- delta to "to" and a debit delta to "from" (empty side skipped). A mint
+-- (empty "from") adds to minted on the credit side; a retire (empty "to") adds
+-- to retired on the debit side.
+TRUNCATE "TokenBalance";
+
+INSERT INTO "TokenBalance" ("address", "tokenId", "amount", "minted", "retired")
+SELECT addr, "tokenId",
+       SUM(amount_delta)::bigint,
+       SUM(minted_delta)::bigint,
+       SUM(retired_delta)::bigint
+FROM (
+    SELECT "to" AS addr, "tokenId",
+           "amount"                                  AS amount_delta,
+           CASE WHEN "from" = '' THEN "amount" ELSE 0 END AS minted_delta,
+           0                                         AS retired_delta
+      FROM "TokenTransaction" WHERE "to" <> ''
+    UNION ALL
+    SELECT "from" AS addr, "tokenId",
+           -"amount"                                 AS amount_delta,
+           0                                         AS minted_delta,
+           CASE WHEN "to" = '' THEN "amount" ELSE 0 END   AS retired_delta
+      FROM "TokenTransaction" WHERE "from" <> ''
+) deltas
+GROUP BY addr, "tokenId"
+HAVING SUM(amount_delta) <> 0 OR SUM(minted_delta) <> 0 OR SUM(retired_delta) <> 0;
+
+-- Down Migration
+--
+-- Restore the amount-only invariant: drop the columns and remove rows that only
+-- existed because of a non-zero minted/retired (net amount zero).
+DELETE FROM "TokenBalance" WHERE "amount" = 0;
+ALTER TABLE "TokenBalance" DROP COLUMN "minted", DROP COLUMN "retired";

--- a/src/postgres/token.ts
+++ b/src/postgres/token.ts
@@ -19,33 +19,55 @@ const createTokenTransactionSql = `
 INSERT INTO "TokenTransaction" ("from", "to", amount, "tokenId") VALUES ($1, $2, $3, $4);
 `;
 
-// Accumulate a signed delta onto an address's running balance for a token, and
-// return the resulting balance. Inserts the row on first sight, otherwise adds
-// to the existing balance. Runs on the same connection (currentPool) as the
+// Accumulate signed deltas onto an address's running totals for a token, and
+// return the resulting row. Inserts on first sight, otherwise adds to the
+// existing totals. Runs on the same connection (currentPool) as the
 // TokenTransaction insert, so the ledger row and the balance update commit
 // atomically within the per-block transaction.
+//
+//   amount  = net holdings (credits - debits)
+//   minted  = cumulative minted TO this address (monotonic)
+//   retired = cumulative retired BY this address (monotonic)
 const upsertTokenBalanceSql = `
-INSERT INTO "TokenBalance" ("address", "tokenId", "amount") VALUES ($1, $2, $3)
+INSERT INTO "TokenBalance" ("address", "tokenId", "amount", "minted", "retired")
+VALUES ($1, $2, $3, $4, $5)
 ON CONFLICT ("address", "tokenId")
-DO UPDATE SET "amount" = "TokenBalance"."amount" + EXCLUDED."amount"
-RETURNING "amount";
+DO UPDATE SET
+  "amount"  = "TokenBalance"."amount"  + EXCLUDED."amount",
+  "minted"  = "TokenBalance"."minted"  + EXCLUDED."minted",
+  "retired" = "TokenBalance"."retired" + EXCLUDED."retired"
+RETURNING "amount", "minted", "retired";
 `;
 
 const deleteTokenBalanceSql = `
 DELETE FROM "TokenBalance" WHERE "address" = $1 AND "tokenId" = $2;
 `;
 
-// A row in "TokenBalance" means "this address currently holds this token", so a
-// balance that nets to zero is removed rather than kept around. The delete only
-// fires on the rare drain-to-zero (detected via RETURNING), so the common
-// transfer path stays a single statement.
+// A row in "TokenBalance" means the address has a non-trivial relationship with
+// the token, matching token_handler's keep-condition exactly: a row is removed
+// only when amount, minted AND retired are all zero (a pure pass-through that
+// netted to nothing). minted/retired are monotonic, so this delete only fires
+// for transfer-through accounts that drained to zero.
 const applyTokenBalanceDelta = async (
   address: string,
   tokenId: string,
-  delta: bigint
+  amount: bigint,
+  minted: bigint,
+  retired: bigint
 ): Promise<void> => {
-  const res = await dbQuery(upsertTokenBalanceSql, [address, tokenId, delta]);
-  if (BigInt(res.rows[0].amount) === 0n) {
+  const res = await dbQuery(upsertTokenBalanceSql, [
+    address,
+    tokenId,
+    amount,
+    minted,
+    retired,
+  ]);
+  const row = res.rows[0];
+  if (
+    BigInt(row.amount) === 0n &&
+    BigInt(row.minted) === 0n &&
+    BigInt(row.retired) === 0n
+  ) {
     await dbQuery(deleteTokenBalanceSql, [address, tokenId]);
   }
 };
@@ -59,11 +81,71 @@ export const createTokenTransaction = async (
   // the sender. `from`/`to` are empty strings for mints/retires, so the empty
   // side is skipped. Self-transfers never reach here (filtered upstream).
   if (t.to) {
-    await applyTokenBalanceDelta(t.to, t.tokenId, t.amount);
+    // empty `from` => this credit is a mint to the recipient
+    const minted = t.from ? 0n : t.amount;
+    await applyTokenBalanceDelta(t.to, t.tokenId, t.amount, minted, 0n);
   }
   if (t.from) {
-    await applyTokenBalanceDelta(t.from, t.tokenId, -t.amount);
+    // empty `to` => this debit is a retire by the sender
+    const retired = t.to ? 0n : t.amount;
+    await applyTokenBalanceDelta(t.from, t.tokenId, -t.amount, 0n, retired);
   }
+};
+
+export type AccountTokenBalance = {
+  tokenId: string;
+  amount: bigint;
+  minted: bigint;
+  retired: bigint;
+  name: string;
+  collection: string;
+  contractAddress: string;
+  description: string;
+  image: string;
+};
+
+// Single indexed read of an address's full holdings, joined to the token /
+// token-class metadata the resolvers need. Replaces scanning + folding the
+// whole TokenTransaction ledger: cost is O(distinct tokens held), and every
+// row is already a "real" entry (zero rows are never stored).
+const getAccountTokenBalancesSql = `
+SELECT b."address", b."tokenId", b."amount", b."minted", b."retired",
+       t."name", t."collection",
+       tc."contractAddress", tc."description", tc."image"
+FROM "TokenBalance" b
+JOIN "Token" t       ON t."id"   = b."tokenId"
+JOIN "TokenClass" tc ON tc."name" = t."name"
+WHERE b."address" = ANY($1::text[])
+  AND ($2::text IS NULL OR t."name" = $2);
+`;
+
+// Batch variant: resolves many addresses in one round-trip (for the entity /
+// collection fan-out resolvers). Returns rows for all addresses; the caller
+// groups by address.
+export const getAccountTokenBalancesBatch = async (
+  addresses: string[],
+  name?: string | null
+): Promise<(AccountTokenBalance & { address: string })[]> => {
+  if (!addresses.length) return [];
+  // Read on the shared pool (not dbQuery/currentPool, which is reserved for the
+  // sync block transaction), matching the other read helpers in this file.
+  const res = await pool.query(getAccountTokenBalancesSql, [
+    addresses,
+    name ?? null,
+  ]);
+  return res.rows;
+};
+
+export const getAccountTokenBalances = async (
+  address: string,
+  name?: string | null
+): Promise<AccountTokenBalance[]> => {
+  if (!address) return [];
+  const res = await pool.query(getAccountTokenBalancesSql, [
+    [address],
+    name ?? null,
+  ]);
+  return res.rows;
 };
 
 const getTokenClassContractAddressSql = `


### PR DESCRIPTION
## What
Extends `TokenBalance` (from #140) with cumulative `minted` and `retired` columns and rewrites the custom token resolvers to read pre-aggregated balances instead of scanning + folding the whole `TokenTransaction` ledger in JS.

## Why
Every token resolver reduces to one primitive — per `(address, tokenId)` → `{amount, minted, retired}` + metadata. The old `getAccountTokens` scanned **all** transactions touching an address (+ N+1 `getTokenClass`), and the entity/collection rollups multiplied that by N entities. Cost grew with the ledger.

| Path | Before | After |
|---|---|---|
| `getAccountTokens(addr)` | O(all txns for addr) + N+1 | one indexed join, O(tokens held) |
| `getTokensTotalForCollection(did)` | N × (scan + N+1) | one batched query |

## How
- **Migration** `20260618…`: add `minted`/`retired`; rebuild table from ledger (keep-rule: a row survives while any of amount/minted/retired ≠ 0 — exactly the handler's old removal condition).
- `createTokenTransaction` maintains all three at the same chokepoint (`minted` on mint-credit, `retired` on retire-debit).
- `getAccountTokens` reads balance rows via one `TokenBalance ⋈ Token ⋈ TokenClass` query — **output shape byte-identical**, so all downstream resolvers and clients are unchanged.
- DataLoader is now a true batch loader (`address = ANY(...)`), one query per name filter → entity/collection fan-outs go N round-trips → 1.

## Verification (pre-deploy, devnet)
Compared live `getAccountTokens` vs an independent reimplementation of the new `{amount, minted, retired}` formula across 40 addresses (incl. retirers/minters): **40/40 match**, covering 252 minted>0 and 9 retired>0 tokens. Typecheck clean.

## Deploy
`npm run migrate:up` (applies `20260618` — alters + rebuilds `TokenBalance`). Resolvers pick up the new path on boot; no client changes.

Authored by: Michael Pretorius <michael@ixo.world>