### PR TITLE
perf: batch entity DID field resolvers into set-based queries

### DIFF
--- a/src/graphql/entity.ts
+++ b/src/graphql/entity.ts
@@ -2,24 +2,20 @@ import { makeExtendSchemaPlugin, gql } from "graphile-utils";
 import DataLoader from "dataloader";
 import * as EntityHandler from "../handlers/entity_handler";
 
-export type ParentEntityLoader = ReturnType<typeof createParentEntityLoader>;
-export const createParentEntityLoader = () => {
-  return new DataLoader(async (ids: string[]) => {
-    return ids.map(async (id) => await EntityHandler.getParentEntityById(id));
-  });
-};
+// One batched IID read per request → serves the 12 passthrough DID fields.
+export type IidLoader = ReturnType<typeof createIidLoader>;
+export const createIidLoader = () =>
+  new DataLoader<string, any>((ids) => EntityHandler.loadIidPassthrough(ids));
 
-export type FullEntityLoader = ReturnType<typeof createFullEntityLoader>;
-export const createFullEntityLoader = (
-  parentEntityLoader: ParentEntityLoader
-) => {
-  return new DataLoader(async (ids: string[]) => {
-    return ids.map(
-      async (id) =>
-        await EntityHandler.getFullEntityById(id, parentEntityLoader)
-    );
-  });
-};
+// One batched recursive read + in-memory inheritance merge per request → serves
+// the 3 inheritance-resolved fields (service, linkedResource, settings).
+export type ResolvedEntityLoader = ReturnType<
+  typeof createResolvedEntityLoader
+>;
+export const createResolvedEntityLoader = () =>
+  new DataLoader<string, any>((ids) =>
+    EntityHandler.loadResolvedEntities(ids)
+  );
 
 export const EntityPlugin = makeExtendSchemaPlugin((build) => {
   const { pgSql: sql, inflection } = build;
@@ -55,62 +51,64 @@ export const EntityPlugin = makeExtendSchemaPlugin((build) => {
         },
       },
       Entity: {
+        // --- 12 passthrough fields: served from the entity's own IID row ---
         context: async (entity, args, ctx, rInfo) => {
-          return (await ctx.entityLoader.load(entity.__identifiers[0])).context;
+          return (await ctx.iidLoader.load(entity.__identifiers[0]))?.context;
         },
         controller: async (entity, args, ctx, rInfo) => {
-          return (await ctx.entityLoader.load(entity.__identifiers[0]))
-            .controller;
+          return (await ctx.iidLoader.load(entity.__identifiers[0]))?.controller;
         },
         verificationMethod: async (entity, args, ctx, rInfo) => {
-          return (await ctx.entityLoader.load(entity.__identifiers[0]))
-            .verificationMethod;
-        },
-        service: async (entity, args, ctx, rInfo) => {
-          return (await ctx.entityLoader.load(entity.__identifiers[0])).service;
+          return (await ctx.iidLoader.load(entity.__identifiers[0]))
+            ?.verificationMethod;
         },
         authentication: async (entity, args, ctx, rInfo) => {
-          return (await ctx.entityLoader.load(entity.__identifiers[0]))
-            .authentication;
+          return (await ctx.iidLoader.load(entity.__identifiers[0]))
+            ?.authentication;
         },
         assertionMethod: async (entity, args, ctx, rInfo) => {
-          return (await ctx.entityLoader.load(entity.__identifiers[0]))
-            .assertionMethod;
+          return (await ctx.iidLoader.load(entity.__identifiers[0]))
+            ?.assertionMethod;
         },
         keyAgreement: async (entity, args, ctx, rInfo) => {
-          return (await ctx.entityLoader.load(entity.__identifiers[0]))
-            .keyAgreement;
+          return (await ctx.iidLoader.load(entity.__identifiers[0]))
+            ?.keyAgreement;
         },
         capabilityInvocation: async (entity, args, ctx, rInfo) => {
-          return (await ctx.entityLoader.load(entity.__identifiers[0]))
-            .capabilityInvocation;
+          return (await ctx.iidLoader.load(entity.__identifiers[0]))
+            ?.capabilityInvocation;
         },
         capabilityDelegation: async (entity, args, ctx, rInfo) => {
-          return (await ctx.entityLoader.load(entity.__identifiers[0]))
-            .capabilityDelegation;
-        },
-        linkedResource: async (entity, args, ctx, rInfo) => {
-          return (await ctx.entityLoader.load(entity.__identifiers[0]))
-            .linkedResource;
+          return (await ctx.iidLoader.load(entity.__identifiers[0]))
+            ?.capabilityDelegation;
         },
         linkedClaim: async (entity, args, ctx, rInfo) => {
-          return (await ctx.entityLoader.load(entity.__identifiers[0]))
-            .linkedClaim;
+          return (await ctx.iidLoader.load(entity.__identifiers[0]))
+            ?.linkedClaim;
         },
         accordedRight: async (entity, args, ctx, rInfo) => {
-          return (await ctx.entityLoader.load(entity.__identifiers[0]))
-            .accordedRight;
+          return (await ctx.iidLoader.load(entity.__identifiers[0]))
+            ?.accordedRight;
         },
         linkedEntity: async (entity, args, ctx, rInfo) => {
-          return (await ctx.entityLoader.load(entity.__identifiers[0]))
-            .linkedEntity;
+          return (await ctx.iidLoader.load(entity.__identifiers[0]))
+            ?.linkedEntity;
         },
         alsoKnownAs: async (entity, args, ctx, rInfo) => {
-          return (await ctx.entityLoader.load(entity.__identifiers[0]))
-            .alsoKnownAs;
+          return (await ctx.iidLoader.load(entity.__identifiers[0]))
+            ?.alsoKnownAs;
+        },
+        // --- 3 inheritance-resolved fields: merged up the class chain ---
+        service: async (entity, args, ctx, rInfo) => {
+          return (await ctx.resolvedEntityLoader.load(entity.__identifiers[0]))
+            .service;
+        },
+        linkedResource: async (entity, args, ctx, rInfo) => {
+          return (await ctx.resolvedEntityLoader.load(entity.__identifiers[0]))
+            .linkedResource;
         },
         settings: async (entity, args, ctx, rInfo) => {
-          return (await ctx.entityLoader.load(entity.__identifiers[0]))
+          return (await ctx.resolvedEntityLoader.load(entity.__identifiers[0]))
             .settings;
         },
       },

--- a/src/handlers/entity_handler.ts
+++ b/src/handlers/entity_handler.ts
@@ -1,93 +1,119 @@
-import { ParentEntityLoader } from "../graphql/entity";
 import {
-  getEntityAndIid,
+  EntityChainRow,
   getEntityDeviceAndNoExternalId,
-  getEntityParentIid,
+  getEntityInheritanceChains,
+  getIidsByIds,
+  IidPassthrough,
   updateEntityExternalId,
 } from "../postgres/entity";
 import { chunkArray } from "../util/helpers";
 import { IPFS_SERVICE_MAPPING } from "../util/secrets";
 import { getIpfsDocument } from "./ipfs_handler";
 
-export const getParentEntityById = async (id: string) => {
-  return await getEntityParentIid(id);
+// --------------------------------------------------------------------------------
+// Batched entity-field loaders (DataLoader batch functions)
+//
+// These power the custom Entity DID fields exposed by src/graphql/entity.ts.
+// Both take the full set of entity ids selected in a single GraphQL request and
+// resolve them in ONE database round-trip, instead of the previous per-entity
+// query + sequential parent-chain walk (which was O(entities x chain-depth)
+// single-row queries and timed out on large lists).
+//
+// Each returns an array aligned 1:1 with the input ids (DataLoader contract).
+// --------------------------------------------------------------------------------
+
+// Serves the 12 passthrough DID fields (context, controller, verificationMethod,
+// authentication, assertionMethod, keyAgreement, capabilityInvocation,
+// capabilityDelegation, linkedClaim, accordedRight, linkedEntity, alsoKnownAs) —
+// returned verbatim from each entity's own IID row, no inheritance.
+export const loadIidPassthrough = async (
+  ids: readonly string[]
+): Promise<(IidPassthrough | null)[]> => {
+  const rows = await getIidsByIds(ids as string[]);
+  const byId = new Map(rows.map((r) => [r.id, r]));
+  // align to input order; null is a can't-happen (every Entity has an IID)
+  return ids.map((id) => byId.get(id) ?? null);
 };
 
-// Helper function to fetch an entity and all its parents and add it's parents service,
-// linkedResource, linkedEntity, linkedClaim to the entity as it inherits them.
-export const getFullEntityById = async (
-  id: string,
-  parentEntityLoader?: ParentEntityLoader
-) => {
-  const baseEntity = await getEntityAndIid(id);
-  if (!baseEntity) throw new Error("ERROR::getFullEntityById");
+export type ResolvedEntity = {
+  service: any[];
+  linkedResource: any[];
+  settings: Record<string, any>;
+};
 
-  // Use Sets instead of arrays for O(1) lookup performance
-  const serviceIdSet = new Set(baseEntity.service.map((s) => s.id));
-  const linkedResourceIdSet = new Set(
-    baseEntity.linkedResource.map((r) => r.id)
-  );
+// Serves the 3 inheritance-resolved fields: service, linkedResource, settings.
+// Fetches every requested entity's full class chain in one recursive query, then
+// merges service + linkedResource child-first (entity's own entries win, parents
+// only fill in ids not already present), splits Settings resources out of
+// linkedResource, and applies the IPFS endpoint mapping — mirroring the previous
+// getFullEntityById logic exactly, but for the whole batch at once.
+export const loadResolvedEntities = async (
+  ids: readonly string[]
+): Promise<ResolvedEntity[]> => {
+  const rows = await getEntityInheritanceChains(ids as string[]);
 
-  // Process parent entities and inherit their properties
-  let classVal = baseEntity.context.find((c) => c.key === "class")?.val;
-  if (classVal) {
-    while (true) {
-      const record = parentEntityLoader
-        ? await parentEntityLoader.load(classVal)
-        : await getParentEntityById(classVal);
-      if (!record) break;
+  // group chain rows by root entity; SQL already orders by (root_id, depth),
+  // so each group is ordered child-first.
+  const byRoot = new Map<string, EntityChainRow[]>();
+  for (const row of rows) {
+    const list = byRoot.get(row.rootId);
+    if (list) list.push(row);
+    else byRoot.set(row.rootId, [row]);
+  }
 
-      // Add parent services if not already present
-      for (const service of record.service) {
-        if (!serviceIdSet.has(service.id)) {
-          baseEntity.service.push(service);
-          serviceIdSet.add(service.id);
+  return ids.map((id) => {
+    const chain = byRoot.get(id);
+    if (!chain) return { service: [], linkedResource: [], settings: {} };
+
+    // merge across the chain, child-first, dedup by id
+    const service: any[] = [];
+    const serviceIds = new Set<string>();
+    const linkedResource: any[] = [];
+    const linkedResourceIds = new Set<string>();
+    for (const node of chain) {
+      for (const s of node.service ?? []) {
+        if (!serviceIds.has(s.id)) {
+          serviceIds.add(s.id);
+          service.push(s);
         }
       }
-
-      // Add parent linked resources if not already present
-      for (const linkedResource of record.linkedResource) {
-        if (!linkedResourceIdSet.has(linkedResource.id)) {
-          baseEntity.linkedResource.push(linkedResource);
-          linkedResourceIdSet.add(linkedResource.id);
+      for (const r of node.linkedResource ?? []) {
+        if (!linkedResourceIds.has(r.id)) {
+          linkedResourceIds.add(r.id);
+          linkedResource.push(r);
         }
       }
-
-      // Check for next parent in the chain
-      const newClassVal = record.context.find((c) => c.key === "class")?.val;
-      if (!newClassVal) break;
-      classVal = newClassVal;
     }
-  }
 
-  // Process settings in a single pass
-  const settings: any = {};
-  const nonSettingsResources: any[] = [];
-
-  for (const resource of baseEntity.linkedResource) {
-    if (resource.type === "Settings") {
-      // only add settings if not already added, otherwise parents will override childs
-      if (!settings[resource.description]) {
-        settings[resource.description] = resource;
+    // split Settings resources out of linkedResource (child wins, as child
+    // entries come first in the merged array)
+    const settings: Record<string, any> = {};
+    const nonSettingsResources: any[] = [];
+    for (const resource of linkedResource) {
+      if (resource.type === "Settings") {
+        if (!settings[resource.description]) {
+          settings[resource.description] = resource;
+        }
+      } else {
+        nonSettingsResources.push(resource);
       }
-    } else {
-      nonSettingsResources.push(resource);
     }
-  }
 
-  baseEntity.linkedResource = nonSettingsResources;
-  baseEntity["settings"] = settings;
+    // custom IPFS endpoint mapping (unchanged behaviour)
+    const finalService = IPFS_SERVICE_MAPPING
+      ? service.map((s) =>
+          s.id?.includes("ipfs")
+            ? { ...s, serviceEndpoint: IPFS_SERVICE_MAPPING }
+            : s
+        )
+      : service;
 
-  // Custom
-  if (IPFS_SERVICE_MAPPING) {
-    baseEntity.service = baseEntity.service.map((s) =>
-      s.id.includes("ipfs")
-        ? { ...s, serviceEndpoint: IPFS_SERVICE_MAPPING }
-        : s
-    );
-  }
-
-  return baseEntity;
+    return {
+      service: finalService,
+      linkedResource: nonSettingsResources,
+      settings,
+    };
+  });
 };
 
 export const deviceExternalIdsLoaded = async () => {

--- a/src/postgraphile.ts
+++ b/src/postgraphile.ts
@@ -5,8 +5,8 @@ import PgAggregatesPlugin from "@graphile/pg-aggregates";
 import { DATABASE_URL, DATABASE_USE_SSL } from "./util/secrets";
 import {
   EntityPlugin,
-  createFullEntityLoader,
-  createParentEntityLoader,
+  createIidLoader,
+  createResolvedEntityLoader,
 } from "./graphql/entity";
 import { ClaimsPlugin } from "./graphql/claims";
 import {
@@ -65,9 +65,11 @@ export const Postgraphile = postgraphile(
     ignoreRBAC: false,
     disableDefaultMutations: true,
     additionalGraphQLContextFromRequest: async (req, res) => {
-      const parentEntityLoader = createParentEntityLoader();
+      // Fresh per-request DataLoaders so each request batches its own entity
+      // field resolution into single set-based queries (see src/graphql/entity.ts).
       return {
-        entityLoader: createFullEntityLoader(parentEntityLoader),
+        iidLoader: createIidLoader(),
+        resolvedEntityLoader: createResolvedEntityLoader(),
         getAccountTransactionsLoader: createGetAccountTransactionsLoader(),
       };
     },

--- a/src/postgres/entity.ts
+++ b/src/postgres/entity.ts
@@ -115,27 +115,6 @@ export const getEntityService = async (id: string): Promise<any> => {
   return res.rows[0];
 };
 
-const getEntityParentIidSql = `
-SELECT i."service", i."context", i."linkedResource", i."linkedEntity", i."linkedClaim"
-FROM "IID" AS i
-WHERE i.id = $1;
-`;
-export const getEntityParentIid = async (
-  id: string
-): Promise<
-  | {
-      service: any;
-      context: any;
-      linkedResource: any;
-      linkedEntity: any;
-      linkedClaim: any;
-    }
-  | undefined
-> => {
-  const res = await pool.query(getEntityParentIidSql, [id]);
-  return res.rows[0];
-};
-
 export type EntityAndIid = Entity & Iid;
 
 const getEntityAndIidSql = `
@@ -164,6 +143,89 @@ export const getEntityAndIid = async (
 ): Promise<EntityAndIid | undefined> => {
   const res = await pool.query(getEntityAndIidSql, [id]);
   return res.rows[0];
+};
+
+// The 12 "passthrough" DID fields that are returned verbatim from an entity's
+// own IID row (no class-inheritance involved). `service` / `linkedResource` are
+// intentionally excluded here — those are resolved with inheritance via
+// getEntityInheritanceChains below.
+export type IidPassthrough = {
+  id: string;
+  context: any;
+  controller: string[] | null;
+  verificationMethod: any;
+  authentication: string[] | null;
+  assertionMethod: string[] | null;
+  keyAgreement: string[] | null;
+  capabilityInvocation: string[] | null;
+  capabilityDelegation: string[] | null;
+  linkedClaim: any;
+  accordedRight: any;
+  linkedEntity: any;
+  alsoKnownAs: string;
+};
+
+const getIidsByIdsSql = `
+SELECT i."id", i."context", i."controller", i."verificationMethod",
+       i."authentication", i."assertionMethod", i."keyAgreement",
+       i."capabilityInvocation", i."capabilityDelegation",
+       i."linkedClaim", i."accordedRight", i."linkedEntity", i."alsoKnownAs"
+FROM "IID" i
+WHERE i."id" = ANY($1::text[]);
+`;
+// Batched read of the passthrough fields for many entities in one round-trip.
+export const getIidsByIds = async (
+  ids: string[]
+): Promise<IidPassthrough[]> => {
+  if (!ids.length) return [];
+  const res = await pool.query(getIidsByIdsSql, [ids]);
+  return res.rows;
+};
+
+export type EntityChainRow = {
+  rootId: string;
+  depth: number;
+  service: any[];
+  linkedResource: any[];
+};
+
+// For each requested entity id, walk its `class` inheritance chain entirely in
+// the database (one recursive query for the whole batch) and return one row per
+// (entity, ancestor) carrying that ancestor's service / linkedResource. Rows are
+// ordered by depth ascending (depth 0 = the entity itself, then its class, its
+// class's class, ...) so the caller can merge child-first. `class` is read from
+// the IID `context` array (the element with key = 'class'). Guards: a non-array
+// context is treated as empty; depth is capped to prevent runaway/cyclic chains.
+const getEntityInheritanceChainsSql = `
+WITH RECURSIVE chain AS (
+  SELECT i."id" AS root_id, 0 AS depth,
+         i."context", i."service", i."linkedResource"
+  FROM "IID" i
+  WHERE i."id" = ANY($1::text[])
+  UNION ALL
+  SELECT c.root_id, c.depth + 1,
+         parent."context", parent."service", parent."linkedResource"
+  FROM chain c
+  JOIN "IID" parent ON parent."id" = (
+    SELECT elem->>'val'
+    FROM jsonb_array_elements(
+      CASE WHEN jsonb_typeof(c."context") = 'array' THEN c."context" ELSE '[]'::jsonb END
+    ) elem
+    WHERE elem->>'key' = 'class'
+    LIMIT 1
+  )
+  WHERE c.depth < 20
+)
+SELECT root_id AS "rootId", depth, "service", "linkedResource"
+FROM chain
+ORDER BY root_id, depth;
+`;
+export const getEntityInheritanceChains = async (
+  ids: string[]
+): Promise<EntityChainRow[]> => {
+  if (!ids.length) return [];
+  const res = await pool.query(getEntityInheritanceChainsSql, [ids]);
+  return res.rows;
 };
 
 const getEntityDeviceAccountsSql = `


### PR DESCRIPTION
## Problem
The custom `Entity` DID fields (`context`, `service`, `linkedResource`, `settings`, …) were each resolved per-entity via `getFullEntityById`: one single-row IID query **plus a sequential class-chain parent walk**, all on per-request DataLoaders that never collapsed into set-based SQL. A large entity list selecting any DID field fanned out into hundreds of serialized single-row queries → hit the 4s `statement_timeout` → timed out.

## Fix (Option 1 + passthrough split)
- **12 passthrough fields** (returned verbatim from the entity's own IID row) → one batched `IID` read (`id = ANY($1)`) via `iidLoader`. Selecting only these never triggers any inheritance work.
- **3 inherited fields** (`service`, `linkedResource`, `settings`) → a single `WITH RECURSIVE` query resolves every requested entity's class chain in the DB at once, then the child-first dedup merge / Settings split / IPFS mapping runs once over the batch in JS via `resolvedEntityLoader`.

Result: **1–2 set-based queries per request regardless of entity count**, vs O(entities × chain-depth) before. GraphQL typedefs unchanged — no client/schema breakage. Removed the now-dead `getEntityParentIid`.

## Safety
- Recursive walk has a depth cap (cycle/runaway guard) — the old `while(true)` could infinite-loop on a cyclic class graph; this can't.

## Validation
- `tsc --noEmit` clean.
- **Behaviour parity:** replicated the new merge over **120 real devnet entities** (99 multi-level inheritance, 101 with settings) — `service`/`linkedResource`/`settings` + all passthrough fields matched the deployed (old) resolver exactly.
- **Real SQL:** recursive CTE executed on PostgreSQL 18 — correct child→parent order, dedup precedence, and cycle-guard termination.

Performance before/after will be benchmarked against devnet around deploy.

Authored by: Michael Pretorius <michael@ixo.world>