### PR TITLE
Release: daodao voting-module → group/staking contract links

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc",
     "dev": "npx ts-node src/index.ts",
     "swagger-gen": "npx ts-node ./src/swagger.ts",
+    "backfill:daodao-contracts": "npx ts-node ./src/scripts/backfill_daodao_voting_contracts.ts",
     "docs-gen": "npx typedoc src/* src/*/*",
     "migrate:up": "node-pg-migrate up -m ./src/postgres/migrations",
     "migrate:down": "node-pg-migrate down  -m ./src/postgres/migrations",

--- a/src/scripts/backfill_daodao_voting_contracts.ts
+++ b/src/scripts/backfill_daodao_voting_contracts.ts
@@ -1,0 +1,187 @@
+/**
+ * One-off backfill: link daodao voting modules to their member/staker contracts.
+ *
+ * Why this exists
+ * ---------------
+ * The daodao wasm-cutoff snapshot historically created `dao_voting_module` rows
+ * WITHOUT `group_contract_address` (cw4) / `staking_contract` (cw20) — see
+ * snapshotVotingModule. Members/stakers were still indexed (keyed by group/
+ * staking contract), but with the link missing they're unreachable via the
+ *   dao_core → dao_voting_module → group/staking contract → members
+ * traversal that GraphQL consumers (e.g. the matrix rooms bot) rely on. Only
+ * DAOs that existed AT the cutoff snapshot are affected; anything created after
+ * it (via live events) already has the link.
+ *
+ * The snapshot is now fixed, so a FRESH reindex is correct. This script repairs
+ * EXISTING DBs that already ran the old snapshot and are now past that height —
+ * without a re-snapshot. It queries the chain once per orphaned module (the
+ * pointer is immutable) and sets the link + refreshes the cached total_weight.
+ *
+ * Usage
+ * -----
+ *   npx ts-node src/scripts/backfill_daodao_voting_contracts.ts [--dry-run]
+ *
+ * Env: DATABASE_URL, IXO_ARCHIVE_NODE_REST_API, NETWORK (same as the indexer).
+ *      BACKFILL_HEIGHT — override the archive query height (defaults to the
+ *      stored snapshot height, else the network's daodao cutoff height).
+ *
+ * Idempotent: only touches rows still missing the link, so it's safe to re-run.
+ */
+import { NETWORK } from "../util/secrets";
+import { DAODAO_CUTOFF_HEIGHTS } from "../constants/daodao_cutoff";
+import { pool, dbQuery } from "../postgres/client";
+import {
+  daoVotingCw4GroupContractQuery,
+  daoVotingCw20StakingContractQuery,
+} from "../util/archive-queries";
+import {
+  getDaodaoSnapshotState,
+  ensureDaoCw4GroupContract,
+  ensureDaoCw20StakingContract,
+  updateDaoVotingModuleGroupContractAddress,
+  updateDaoVotingModuleTokenStakingContractAddress,
+  getDaoCw4SumWeightForGroupContract,
+  getDaoCw20StakersSumStakedForContract,
+  updateDaoAllVotingModulesTotalWeightForGroupContract,
+  updateDaoAllVotingModulesTotalWeightForCw20Contract,
+} from "../postgres/dao";
+
+const log = (...args: any[]) => console.log("[backfill-daodao]", ...args);
+
+const resolveHeight = async (): Promise<number> => {
+  const envH = Number(process.env.BACKFILL_HEIGHT);
+  if (Number.isFinite(envH) && envH > 0) return envH;
+  const snap = await getDaodaoSnapshotState();
+  if (snap?.snapshot_height) return snap.snapshot_height;
+  const cutoff = DAODAO_CUTOFF_HEIGHTS[NETWORK];
+  if (cutoff) return cutoff;
+  throw new Error(
+    "Could not determine a query height — set BACKFILL_HEIGHT explicitly."
+  );
+};
+
+const main = async () => {
+  const dryRun = process.argv.includes("--dry-run");
+  const height = await resolveHeight();
+  log(`network=${NETWORK} height=${height} dryRun=${dryRun}`);
+
+  const cw4Orphans = (
+    await dbQuery(
+      `SELECT address FROM dao_voting_module
+        WHERE module_type = 'dao_voting_cw4' AND group_contract_address IS NULL
+        ORDER BY address;`
+    )
+  ).rows.map((r: any) => r.address as string);
+  const cw20Orphans = (
+    await dbQuery(
+      `SELECT address FROM dao_voting_module
+        WHERE module_type = 'dao_voting_cw20_staked' AND staking_contract IS NULL
+        ORDER BY address;`
+    )
+  ).rows.map((r: any) => r.address as string);
+  log(`orphans: cw4=${cw4Orphans.length} cw20=${cw20Orphans.length}`);
+
+  let cw4Linked = 0;
+  let cw4NoContract = 0;
+  let cw20Linked = 0;
+  let cw20NoContract = 0;
+  const errors: Array<{ address: string; error: string }> = [];
+
+  for (let i = 0; i < cw4Orphans.length; i++) {
+    const address = cw4Orphans[i];
+    const tag = `[cw4 ${i + 1}/${cw4Orphans.length}] ${address}`;
+    try {
+      const groupContract = await daoVotingCw4GroupContractQuery(
+        height,
+        address
+      );
+      if (!groupContract) {
+        cw4NoContract++;
+        log(`${tag} → no group_contract returned, skipping`);
+        continue;
+      }
+      if (dryRun) {
+        log(`${tag} → would link group_contract=${groupContract}`);
+        cw4Linked++;
+        continue;
+      }
+      await ensureDaoCw4GroupContract(groupContract);
+      await updateDaoVotingModuleGroupContractAddress({
+        address,
+        group_contract_address: groupContract,
+      });
+      const totalWeight = await getDaoCw4SumWeightForGroupContract(
+        groupContract
+      );
+      await updateDaoAllVotingModulesTotalWeightForGroupContract(
+        groupContract,
+        totalWeight.toString()
+      );
+      cw4Linked++;
+      log(`${tag} → linked group_contract=${groupContract} weight=${totalWeight}`);
+    } catch (error: any) {
+      const msg = error?.message ?? String(error);
+      errors.push({ address, error: msg });
+      log(`${tag} → ERROR ${msg}`);
+    }
+  }
+
+  for (let i = 0; i < cw20Orphans.length; i++) {
+    const address = cw20Orphans[i];
+    const tag = `[cw20 ${i + 1}/${cw20Orphans.length}] ${address}`;
+    try {
+      const stakingContract = await daoVotingCw20StakingContractQuery(
+        height,
+        address
+      );
+      if (!stakingContract) {
+        cw20NoContract++;
+        log(`${tag} → no staking_contract returned, skipping`);
+        continue;
+      }
+      if (dryRun) {
+        log(`${tag} → would link staking_contract=${stakingContract}`);
+        cw20Linked++;
+        continue;
+      }
+      await ensureDaoCw20StakingContract(stakingContract);
+      await updateDaoVotingModuleTokenStakingContractAddress({
+        address,
+        staking_contract: stakingContract,
+      });
+      const totalWeight = await getDaoCw20StakersSumStakedForContract(
+        stakingContract
+      );
+      await updateDaoAllVotingModulesTotalWeightForCw20Contract(
+        stakingContract,
+        totalWeight.toString()
+      );
+      cw20Linked++;
+      log(
+        `${tag} → linked staking_contract=${stakingContract} weight=${totalWeight}`
+      );
+    } catch (error: any) {
+      const msg = error?.message ?? String(error);
+      errors.push({ address, error: msg });
+      log(`${tag} → ERROR ${msg}`);
+    }
+  }
+
+  log("==== summary ====");
+  log(`cw4:  linked=${cw4Linked} noContract=${cw4NoContract} total=${cw4Orphans.length}`);
+  log(`cw20: linked=${cw20Linked} noContract=${cw20NoContract} total=${cw20Orphans.length}`);
+  log(`errors=${errors.length}`);
+  for (const e of errors) log(`  ! ${e.address}: ${e.error}`);
+  if (dryRun) log("DRY RUN — no rows were written.");
+};
+
+main()
+  .then(async () => {
+    await pool.end();
+    process.exit(0);
+  })
+  .catch(async (error) => {
+    console.error("[backfill-daodao] FATAL", error);
+    await pool.end();
+    process.exit(1);
+  });

--- a/src/sync/daodao_snapshot.ts
+++ b/src/sync/daodao_snapshot.ts
@@ -13,6 +13,8 @@ import {
   daoProposalModuleProposalCreationPolicyQuery,
   daoPreProposalModuleConfigQuery,
   daoVotingModuleActiveThresholdQuery,
+  daoVotingCw4GroupContractQuery,
+  daoVotingCw20StakingContractQuery,
   cw4GroupMembersQuery,
   cw20StakeConfigQuery,
   cw721StakeConfigQuery,
@@ -294,12 +296,35 @@ const snapshotVotingModule = async (
     unstakingDuration = cfg?.unstaking_duration;
   }
 
-  // Note: token_address / staking_contract / group_contract_address are
-  // populated AFTER this row exists, via the post-pass that walks the
-  // dao_core dump_state output (which tells us which voting module
-  // belongs to which DAO + what its underlying contracts are). For now
-  // we write the bare row; the dao_core pass + member/staker passes fill
-  // in the rest.
+  // Link this voting module to its underlying member/staker contract.
+  // dao_core dump_state (Pass 4) gives us the voting_module address but NOT its
+  // cw4-group / cw20-stake contract — that needs a per-module smart-query, the
+  // same `group_contract` / `staking_contract` lookup the live instantiate
+  // handler does (it reads them from event attributes; the snapshot has no
+  // event). Without this link the members/stakers Pass 7 writes (keyed by the
+  // group/staking contract) are unreachable via the
+  // dao_core → voting_module → group/staking → members traversal.
+  let groupContractAddress: string | undefined;
+  let stakingContract: string | undefined;
+  if (contractType === "dao_voting_cw4") {
+    const g = await daoVotingCw4GroupContractQuery(ctx.snapshotHeight, address);
+    if (g) {
+      // Ensure the FK target exists even if the group was instantiated outside
+      // the tracked daodao code-ids (idempotent; Pass 1 also ensures these).
+      await ensureDaoCw4GroupContract(g);
+      groupContractAddress = g;
+    }
+  } else if (contractType === "dao_voting_cw20_staked") {
+    const s = await daoVotingCw20StakingContractQuery(
+      ctx.snapshotHeight,
+      address
+    );
+    if (s) {
+      await ensureDaoCw20StakingContract(s);
+      stakingContract = s;
+    }
+  }
+
   await createDaoVotingModule({
     address,
     module_type: contractType,
@@ -307,6 +332,8 @@ const snapshotVotingModule = async (
     block_height: ctx.snapshotHeight,
     active_threshold: activeThreshold,
     nft_contract: undefined,
+    group_contract_address: groupContractAddress,
+    staking_contract: stakingContract,
     unstaking_duration: unstakingDuration,
     total_weight: "0",
     native_denom: nativeDenom ?? undefined,

--- a/src/util/archive-queries.ts
+++ b/src/util/archive-queries.ts
@@ -511,6 +511,36 @@ export const daoVotingModuleActiveThresholdQuery = async (
   return result?.data?.active_threshold;
 };
 
+// dao-voting-cw4: GroupContract {} → the cw4-group contract address (Addr).
+// The live instantiate handler reads this from the `group_contract_address`
+// event attribute; the snapshot has no event, so it queries it directly.
+export const daoVotingCw4GroupContractQuery = async (
+  height: number,
+  contractAddress: string
+): Promise<string | null> => {
+  const query = jsonToBase64({ group_contract: {} });
+  const result = await queryArchiveApi(
+    `/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${query}`,
+    height
+  );
+  // Example return: { "data": "ixo1...groupcontract" }
+  return typeof result?.data === "string" ? result.data : null;
+};
+
+// dao-voting-cw20-staked: StakingContract {} → the cw20-stake contract address (Addr).
+export const daoVotingCw20StakingContractQuery = async (
+  height: number,
+  contractAddress: string
+): Promise<string | null> => {
+  const query = jsonToBase64({ staking_contract: {} });
+  const result = await queryArchiveApi(
+    `/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${query}`,
+    height
+  );
+  // Example return: { "data": "ixo1...stakingcontract" }
+  return typeof result?.data === "string" ? result.data : null;
+};
+
 // ======================================
 // CW721 Staking Queries
 // ======================================


### PR DESCRIPTION
Promotes `develop` → `main`.

## Included

**#145 — feat(daodao): link voting modules to their group/staking contracts**

The daodao cutoff snapshot wrote `dao_voting_module` rows from `dump_state`, which exposes the voting-module address but not its underlying cw4-group / cw20-stake contract — so `group_contract_address` / `staking_contract` were left `NULL` and the indexed members/stakers were unreachable via the `dao_core → dao_voting_module → group/staking → members` traversal.

- `snapshotVotingModule` now smart-queries and sets the link inline, so any fresh reindex is correct (no migration).
- New `daoVotingCw4GroupContractQuery` / `daoVotingCw20StakingContractQuery` archive helpers.
- `src/scripts/backfill_daodao_voting_contracts.ts` (+ `yarn backfill:daodao-contracts`): idempotent one-off repair for existing DBs already past the snapshot height.

## Status

- **devnet:** deployed (`v2.5.0-develop.8`) and backfilled — 103 cw4 + 23 cw20 linked, orphans now 0/0, verified end-to-end.
- **testnet / mainnet:** after this merges + deploys, run the backfill once per env in the `ixo-blocksync` pod (namespace `core`). Outstanding orphans: testnet 68 cw4 + 21 cw20; mainnet 47 cw4 + 5 cw20. (cw721/native need no backfill — keyed by voting-module address directly; native has 0 modules anywhere, cw721 only exists on devnet.)

Authored by: Michael Pretorius <michael@ixo.world>