### PR TITLE
feat: query performance indexes, pool right-sizing and Sentry trace sampling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,13 @@ TRUST_PROXY=1
 NODE_ENV=production
 
 SENTRYDSN=
+# fraction of requests Sentry traces (0.0 - 1.0), errors are always captured
+SENTRY_TRACES_SAMPLE_RATE=0.1
+
+# max clients in the shared app/sync pg pool (optional, default 20)
+DATABASE_POOL_MAX=20
+# max clients in Postgraphile's GraphQL pg pool (optional, default 30)
+GRAPHQL_POOL_MAX=30
 
 RPC=
 # the below ixo node api endpoint must be a full archive node api, used for epoch indexing

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,7 +8,11 @@ import * as EntityHandler from "./handlers/entity_handler";
 import * as IpfsHandler from "./handlers/ipfs_handler";
 import * as ClaimsHandler from "./handlers/claims_handler";
 import * as TokenomicsHandler from "./handlers/tokenomics_handler";
-import { SENTRYDSN, TRUST_PROXY } from "./util/secrets";
+import {
+  SENTRYDSN,
+  SENTRY_TRACES_SAMPLE_RATE,
+  TRUST_PROXY,
+} from "./util/secrets";
 import swaggerUi from "swagger-ui-express";
 import helmet from "helmet";
 import rateLimit from "express-rate-limit";
@@ -28,7 +32,9 @@ const limiter = rateLimit({
 export const app = express();
 app.set("trust proxy", TRUST_PROXY);
 
-Sentry.init({ dsn: SENTRYDSN, tracesSampleRate: 1.0 });
+// Sample traces instead of tracing every request (1.0 added measurable
+// per-request overhead in prod); error capture is unaffected.
+Sentry.init({ dsn: SENTRYDSN, tracesSampleRate: SENTRY_TRACES_SAMPLE_RATE });
 app.use(cors());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());

--- a/src/postgraphile.ts
+++ b/src/postgraphile.ts
@@ -1,8 +1,13 @@
 import postgraphile from "postgraphile";
+import { Pool } from "pg";
 import PgSimplifyInflectorPlugin from "@graphile-contrib/pg-simplify-inflector";
 import ConnectionFilterPlugin from "postgraphile-plugin-connection-filter";
 import PgAggregatesPlugin from "@graphile/pg-aggregates";
-import { DATABASE_URL, DATABASE_USE_SSL } from "./util/secrets";
+import {
+  DATABASE_URL,
+  DATABASE_USE_SSL,
+  GRAPHQL_POOL_MAX,
+} from "./util/secrets";
 import {
   EntityPlugin,
   createIidLoader,
@@ -19,23 +24,32 @@ import { SmartTagsPlugin } from "./graphql/smart_tags_plugin";
 const isProd = process.env.NODE_ENV === "production";
 console.log("isProd: ", isProd);
 
+// Explicit pool (instead of a config object) so we can attach an error
+// handler - an errored idle client must never crash the process.
+const graphqlPool = new Pool({
+  application_name: "Blocksync-graphql",
+  connectionString: DATABASE_URL,
+  // maximum number of clients the pool should contain
+  // (the cluster's max_connections is shared with every other service;
+  // requests queue briefly for a free client instead of stampeding postgres)
+  max: GRAPHQL_POOL_MAX,
+  // number of milliseconds a client must sit idle in the pool and not be checked out
+  // before it is disconnected from the backend and discarded
+  idleTimeoutMillis: 30000,
+  // TCP keepalive so idle clients survive LB/tunnel idle-connection drops
+  keepAlive: true,
+  // number of milliseconds to wait before timing out when connecting a new client
+  // by default this is 0 which means no timeout
+  connectionTimeoutMillis: 8000,
+  ...(DATABASE_USE_SSL && { ssl: { rejectUnauthorized: false } }), // Use SSL (recommended
+});
+
+graphqlPool.on("error", (err) => {
+  console.error("ERROR::graphqlPgPool::", err.message);
+});
+
 export const Postgraphile = postgraphile(
-  {
-    application_name: "Blocksync-graphql",
-    connectionString: DATABASE_URL,
-    // maximum number of clients the pool should contain
-    // by default this is set to 10.
-    max: 100,
-    // min: 3,
-    // number of milliseconds a client must sit idle in the pool and not be checked out
-    // before it is disconnected from the backend and discarded
-    // default is 10000 (10 seconds) - set to 0 to disable auto-disconnection of idle clients
-    // idleTimeoutMillis: 10000,
-    // number of milliseconds to wait before timing out when connecting a new client
-    // by default this is 0 which means no timeout
-    connectionTimeoutMillis: 8000,
-    ...(DATABASE_USE_SSL && { ssl: { rejectUnauthorized: false } }), // Use SSL (recommended
-  },
+  graphqlPool,
   "public",
   {
     ...(isProd

--- a/src/postgres/blocksync_core/client.ts
+++ b/src/postgres/blocksync_core/client.ts
@@ -11,10 +11,17 @@ export const corePool = new Pool({
   // before it is disconnected from the backend and discarded
   // default is 10000 (10 seconds) - set to 0 to disable auto-disconnection of idle clients
   idleTimeoutMillis: 10000,
+  // TCP keepalive so idle clients survive LB/tunnel idle-connection drops
+  keepAlive: true,
   // number of milliseconds to wait before timing out when connecting a new client
   // by default this is 0 which means no timeout
   connectionTimeoutMillis: 1000,
   ...(DATABASE_USE_SSL && { ssl: { rejectUnauthorized: false } }), // Use SSL (recommended
+});
+
+// An errored idle client must never crash the process.
+corePool.on("error", (err) => {
+  console.error("ERROR::corePgPool::", err.message);
 });
 
 // helper function that manages connect to pool and release,

--- a/src/postgres/client.ts
+++ b/src/postgres/client.ts
@@ -1,22 +1,34 @@
 import { Pool, PoolClient } from "pg";
-import { DATABASE_URL, DATABASE_USE_SSL } from "../util/secrets";
+import {
+  DATABASE_POOL_MAX,
+  DATABASE_URL,
+  DATABASE_USE_SSL,
+} from "../util/secrets";
 import { currentPool } from "../sync/sync_blocks";
 
 export const pool = new Pool({
   application_name: "Blocksync",
   connectionString: DATABASE_URL,
   // maximum number of clients the pool should contain
-  // by default this is set to 10.
-  max: 100,
+  // (the cluster's max_connections is shared with every other service;
+  // requests queue briefly for a free client instead of stampeding postgres)
+  max: DATABASE_POOL_MAX,
   min: 3,
   // number of milliseconds a client must sit idle in the pool and not be checked out
   // before it is disconnected from the backend and discarded
-  // default is 10000 (10 seconds) - set to 0 to disable auto-disconnection of idle clients
-  // idleTimeoutMillis: 10000,
+  idleTimeoutMillis: 30000,
+  // TCP keepalive so idle clients survive LB/tunnel idle-connection drops
+  keepAlive: true,
   // number of milliseconds to wait before timing out when connecting a new client
   // by default this is 0 which means no timeout
   connectionTimeoutMillis: 8000,
   ...(DATABASE_USE_SSL && { ssl: { rejectUnauthorized: false } }), // Use SSL (recommended
+});
+
+// An errored idle client must never crash the process (idle connections
+// dropped by load balancers / tunnels surface here).
+pool.on("error", (err) => {
+  console.error("ERROR::pgpool::", err.message);
 });
 
 // helper function that manages connection transaction start and commit and rollback

--- a/src/postgres/migrations/20260710000000000_query-performance-indexes.sql
+++ b/src/postgres/migrations/20260710000000000_query-performance-indexes.sql
@@ -1,0 +1,40 @@
+-- Up Migration
+
+-- Query-performance indexes for the public GraphQL/REST API, verified July
+-- 2026 against a mainnet copy (measurements in the ixo-blocksync-api repo,
+-- docs/verification-2026-07.md).
+
+-- Wallet transaction pollers filter Message on "from" / "to" independently
+-- (or: [{from: {equalTo}}, {to: {equalTo}}]). The existing composite index
+-- leads with "transactionHash", so those filters were sequential scans:
+-- ~130ms per request on ~1M rows, ~4ms with these partial indexes.
+CREATE INDEX IF NOT EXISTS "Message_from_idx"
+  ON "Message"("from") WHERE "from" IS NOT NULL;
+CREATE INDEX IF NOT EXISTS "Message_to_idx"
+  ON "Message"("to") WHERE "to" IS NOT NULL;
+
+-- typeUrl is filtered with equalTo / in and exact-string LIKE by clients.
+-- text_pattern_ops serves both equality and LIKE prefix matching under the
+-- cluster's en_US.utf-8 collation (a default-collation btree would only
+-- serve equality).
+CREATE INDEX IF NOT EXISTS "Message_typeUrl_idx"
+  ON "Message"("typeUrl" text_pattern_ops);
+
+-- getAccountTokens(allEntityRetired: true) sums TokenRetired amounts grouped
+-- by token id ("id" = ANY(...)). The existing (name, owner, id) composite
+-- cannot serve id-only lookups.
+CREATE INDEX IF NOT EXISTS "TokenRetired_id_idx" ON "TokenRetired"("id");
+
+-- Collection claim lists paginate ordered by (submissionDate, claimId) within
+-- a collection (REST /api/claims/collection/:id/claims and the GraphQL
+-- SUBMISSION_DATE_* orderBys).
+CREATE INDEX IF NOT EXISTS "Claim_collectionId_submissionDate_idx"
+  ON "Claim"("collectionId", "submissionDate" DESC, "claimId");
+
+-- Down Migration
+
+DROP INDEX IF EXISTS "Claim_collectionId_submissionDate_idx";
+DROP INDEX IF EXISTS "TokenRetired_id_idx";
+DROP INDEX IF EXISTS "Message_typeUrl_idx";
+DROP INDEX IF EXISTS "Message_to_idx";
+DROP INDEX IF EXISTS "Message_from_idx";

--- a/src/util/secrets.ts
+++ b/src/util/secrets.ts
@@ -15,3 +15,20 @@ export const DATABASE_USE_SSL =
   Number(process.env.DATABASE_USE_SSL ?? "0") || 0;
 export const STATIC_CHAIN_ID = process.env.STATIC_CHAIN_ID;
 export const NETWORK = process.env.NETWORK || "devnet";
+
+// Max clients for the shared app/sync pg pool. The cluster's max_connections
+// is shared by every service, and a pg connection is a whole backend process;
+// small pools that queue briefly under load outperform large ones that
+// stampede the database.
+export const DATABASE_POOL_MAX =
+  Number(process.env.DATABASE_POOL_MAX ?? "20") || 20;
+// Max clients for Postgraphile's GraphQL pool.
+export const GRAPHQL_POOL_MAX =
+  Number(process.env.GRAPHQL_POOL_MAX ?? "30") || 30;
+
+// Fraction of requests Sentry traces (1.0 traced every request in prod,
+// which adds per-request overhead and quota burn).
+const sentryRate = Number(process.env.SENTRY_TRACES_SAMPLE_RATE);
+export const SENTRY_TRACES_SAMPLE_RATE = Number.isFinite(sentryRate)
+  ? sentryRate
+  : 0.1;


### PR DESCRIPTION
## What

- **New migration `20260710000000000_query-performance-indexes.sql`** — indexes verified against a mainnet copy (measurements in the ixo-blocksync-api repo, `docs/verification-2026-07.md`):
  - `Message(from)` / `Message(to)` partial indexes — wallet transaction pollers filtered these with no usable index: ~130ms sequential scan per request → ~4ms
  - `Message(typeUrl text_pattern_ops)` — serves `equalTo`/`in` **and** the exact-string `LIKE` filters clients send (cluster collation is en_US.utf-8, so a default btree would not cover LIKE)
  - `TokenRetired(id)` — `getAccountTokens(allEntityRetired: true)` sums; existing composite leads with `name`
  - `Claim(collectionId, submissionDate DESC, claimId)` — collection claim list pagination
- **Pool right-sizing + hardening**: GraphQL pool 100 → 30 (`GRAPHQL_POOL_MAX`), app/sync pool 100 → 20 (`DATABASE_POOL_MAX`); all three pools get `keepAlive`, explicit idle timeouts and `pool.on("error")` handlers so an idle-connection drop can never crash the process. The Postgraphile pool is now created explicitly to make the error handler possible. (Cluster max_connections is 200 shared by ~24 services; the previous config allowed up to 200 from this one process while actually using ~7.)
- **Sentry**: `tracesSampleRate` 1.0 → 0.1 (env-tunable `SENTRY_TRACES_SAMPLE_RATE`) — tracing every request added per-request overhead; error capture unchanged.

## Testing

- Migration up + down + re-up run via node-pg-migrate against a full mainnet dump on Postgres 15; boot-time programmatic migration path verified ("No migrations to run!" once applied)
- Query timings before/after measured on the mainnet copy; behaviour parity of GraphQL responses unaffected (indexes + config only)
- `tsc` clean; boot smoke test against the mainnet copy serves GraphQL normally

Authored by: Michael Pretorius <michael@ixo.world>