### PR TITLE
feat: GIN indexes for IID jsonb containment + partial claim schema-type index

### DIFF
--- a/src/postgres/migrations/20260710120000000_iid-jsonb-and-claim-schematype-indexes.sql
+++ b/src/postgres/migrations/20260710120000000_iid-jsonb-and-claim-schematype-indexes.sql
@@ -1,0 +1,30 @@
+-- Up Migration
+
+-- Follow-up to 20260710000000000_query-performance-indexes: indexes found by
+-- profiling the custom resolver SQL against a mainnet copy.
+
+-- JSONB containment lookups on IID. Clients resolve entities by class
+-- (context @> [{key:'class', val:<did>}] - collection listings and the
+-- getTokensTotalForCollection* fan-out) and offers/KYC by linked collection
+-- (linkedEntity @> [{type:'ClaimCollection', id:<id>}]); both were full
+-- jsonb scans of the IID table (52ms / 9ms -> ~4ms / ~0.1ms). Default GIN
+-- opclass so the API's containsKey/containsAllKeys filters are also served.
+CREATE INDEX IF NOT EXISTS "IID_context_gin_idx"
+  ON "IID" USING gin ("context");
+CREATE INDEX IF NOT EXISTS "IID_linkedEntity_gin_idx"
+  ON "IID" USING gin ("linkedEntity");
+
+-- ClaimCollection.claimSchemaTypesLoaded checks for claims with a NULL
+-- schemaType inside a collection; on large collections the planner fell back
+-- to scanning every claim (~43ms on a 113k-claim collection). This partial
+-- index only ever contains the not-yet-typed claims (normally none), making
+-- the check an index-only scan (~0.05ms). Also serves the schema-type cron's
+-- per-collection lookups.
+CREATE INDEX IF NOT EXISTS "Claim_collectionId_schemaType_null_idx"
+  ON "Claim"("collectionId") WHERE "schemaType" IS NULL;
+
+-- Down Migration
+
+DROP INDEX IF EXISTS "Claim_collectionId_schemaType_null_idx";
+DROP INDEX IF EXISTS "IID_linkedEntity_gin_idx";
+DROP INDEX IF EXISTS "IID_context_gin_idx";


### PR DESCRIPTION
Follow-up to #147, found by profiling the custom resolver SQL against a mainnet copy. New migration `20260710120000000_iid-jsonb-and-claim-schematype-indexes.sql`:

| Index | Serves | Before → After |
| --- | --- | --- |
| GIN on `IID.context` | entity-by-class containment lookups — collection listings and the `getTokensTotalForCollection*` fan-out (`context @> [{key:'class', ...}]`) | 52ms → ~4ms |
| GIN on `IID.linkedEntity` | offer/KYC lookups (`linkedEntity @> [{type:'ClaimCollection', ...}]`) | 9.4ms → ~0.1ms |
| Partial `Claim(collectionId) WHERE "schemaType" IS NULL` | `claimSchemaTypesLoaded` on large collections — the index only ever contains not-yet-typed claims (normally zero rows) | 42.6ms → ~0.05ms |

Default GIN opclass (not jsonb_path_ops) so the API's `containsKey`/`containsAllKeys` filter operators are index-served too.

## Testing

- Migration up + down verified with node-pg-migrate against a full mainnet dump on Postgres 15, including on a DB that had already run #147's migration
- Plans confirmed via EXPLAIN ANALYZE (bitmap index scans / index-only scan)
- End-to-end through GraphQL: offer lookup 17ms, collection entity listing 16ms, collection token totals (498-entity fan-out) 29ms

Authored by: Michael Pretorius <michael@ixo.world>