### PR TITLE
feat: notify trigger on Chain for per-block cache invalidation

### DIFF
--- a/src/postgres/migrations/20260710130000000_block-notify-trigger.sql
+++ b/src/postgres/migrations/20260710130000000_block-notify-trigger.sql
@@ -1,0 +1,26 @@
+-- Up Migration
+
+-- Emit a NOTIFY whenever a block finishes indexing. The sync loop updates
+-- "Chain"."blockHeight" inside every per-block transaction, so this trigger
+-- fires exactly once per indexed block, at commit, i.e. the exact moment new
+-- chain data becomes visible to readers.
+--
+-- Consumed by ixo-blocksync-api's block-aware response cache (LISTEN
+-- blocksync_new_block -> flush), which makes cached responses impossible to
+-- be staler than the database. Harmless without listeners; NOTIFY on a
+-- channel nobody LISTENs to is a no-op.
+CREATE OR REPLACE FUNCTION notify_blocksync_new_block() RETURNS trigger AS $$
+BEGIN
+  PERFORM pg_notify('blocksync_new_block', NEW."blockHeight"::text);
+  RETURN NEW;
+END $$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS blocksync_new_block_trigger ON "Chain";
+CREATE TRIGGER blocksync_new_block_trigger
+AFTER INSERT OR UPDATE ON "Chain"
+FOR EACH ROW EXECUTE FUNCTION notify_blocksync_new_block();
+
+-- Down Migration
+
+DROP TRIGGER IF EXISTS blocksync_new_block_trigger ON "Chain";
+DROP FUNCTION IF EXISTS notify_blocksync_new_block();


### PR DESCRIPTION
Adds migration `20260710130000000_block-notify-trigger.sql`: a trigger on `"Chain"` that emits `pg_notify('blocksync_new_block', <height>)` whenever a block finishes indexing (the sync loop updates `blockHeight` inside every per-block transaction, so the NOTIFY fires exactly once per block, at commit — the precise moment new chain data becomes visible to readers).

This powers ixo-blocksync-api's block-aware response cache: the API LISTENs on the channel and flushes its whole cache on every notification, so a cached response can never be staler than the database itself. A transaction indexed in block N flushes the cache before anyone can query it.

- Harmless with no listeners: NOTIFY on an unlistened channel is a no-op, and the indexer's write path is unchanged (one trigger invocation per block).
- Proper down migration (drops trigger + function).

## Testing

- Migration up + down + re-up via node-pg-migrate against a full mainnet dump (Postgres 15)
- End-to-end with the API's cache: cached response served as HIT, block-height bump committed, next request within 300ms returned MISS with the new data (trigger-driven; the API also has a 5s poll backstop if this migration isn't deployed yet)

Authored by: Michael Pretorius <michael@ixo.world>