### PR TITLE
fix: promote TokenClass name unique index to constraint

### DIFF
--- a/src/postgres/migrations/20260715120000000_tokenclass-name-unique-constraint.sql
+++ b/src/postgres/migrations/20260715120000000_tokenclass-name-unique-constraint.sql
@@ -1,0 +1,28 @@
+-- Up Migration
+
+-- "TokenClass"."name" is the target of three foreign keys
+-- (Token/TokenRetired/TokenCancelled "name") but its uniqueness comes from a
+-- Prisma-era plain UNIQUE INDEX rather than a UNIQUE CONSTRAINT. Postgres
+-- accepts FKs onto a unique index, but PostGraphile 5 (ixo-blocksync-api)
+-- only recognizes constraints (pg_constraint) as uniques, so the single-row
+-- tokenClassByName relations fail at plan time ("combination of attributes
+-- is not unique"). Promote the index to a constraint in place: instant
+-- metadata-only change, the existing index is adopted (same name/OID), and
+-- the dependent FKs are unaffected.
+-- NOTE: ixo-blocksync-api pods must restart after this runs - the API
+-- introspects the database once at boot.
+ALTER TABLE "TokenClass"
+  ADD CONSTRAINT "TokenClass_name_key" UNIQUE USING INDEX "TokenClass_name_key";
+
+-- Down Migration
+
+-- Demote back to a plain unique index. The dependent FKs must be dropped
+-- first (they depend on the constraint's index) and re-added afterwards.
+ALTER TABLE "Token" DROP CONSTRAINT "Token_name_fkey";
+ALTER TABLE "TokenRetired" DROP CONSTRAINT "TokenRetired_name_fkey";
+ALTER TABLE "TokenCancelled" DROP CONSTRAINT "TokenCancelled_name_fkey";
+ALTER TABLE "TokenClass" DROP CONSTRAINT "TokenClass_name_key";
+CREATE UNIQUE INDEX "TokenClass_name_key" ON "TokenClass"("name");
+ALTER TABLE "Token" ADD CONSTRAINT "Token_name_fkey" FOREIGN KEY ("name") REFERENCES "TokenClass"("name") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "TokenRetired" ADD CONSTRAINT "TokenRetired_name_fkey" FOREIGN KEY ("name") REFERENCES "TokenClass"("name") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "TokenCancelled" ADD CONSTRAINT "TokenCancelled_name_fkey" FOREIGN KEY ("name") REFERENCES "TokenClass"("name") ON DELETE RESTRICT ON UPDATE CASCADE;


### PR DESCRIPTION
Fixes the `tokenClassByName` runtime error a dev hit on devnet (reproduces on **all** environments, e.g. `tokenBalances → token → tokenClassByName`):

> `Attempted to call PgResource(TokenClass).get({name}) ... but that combination of attributes is not unique`

**Root cause:** `TokenClass.name` is the target of three FKs (`Token`/`TokenRetired`/`TokenCancelled` `.name`), but its uniqueness comes from a Prisma-era plain `CREATE UNIQUE INDEX` rather than a `UNIQUE` constraint. Postgres accepts FKs onto a unique index, and PostGraphile **v4** recognized unique indexes — but **v5** (ixo-blocksync-api) only reads uniques from `pg_constraint`, so the single-row `tokenClassByName` relations on all three tables fail at plan time. It's the only FK target in the whole schema with this shape (swept every migration).

**Fix:** new migration promoting the index to a constraint **in place** — `ADD CONSTRAINT ... UNIQUE USING INDEX` adopts the existing index (same name, metadata-only, instant, dependent FKs unaffected). Down migration faithfully restores the index-only state (drops/re-adds the three FKs around it).

**Validated on a scratch DB reproducing the schema shape:** up → constraint appears in `pg_constraint` as `contype u` (exactly what v5 introspects), down → clean restore, redo → works, FK still enforced after promotion.

**Deploy note:** after this migration runs (indexer boot via `MIGRATE_DB_PROGRAMATICALLY`), the ixo-blocksync-api pods need a `kubectl rollout restart` per environment — the API introspects the DB once at boot. No API code change or image build needed.

Authored by: Michael Pretorius <michael@ixo.world>