### PR TITLE
feat: indexes for the subscriptions unevaluated-claims poller

### DIFF
--- a/src/postgres/migrations/20260720100000000_unevaluated-claims-poll-indexes.sql
+++ b/src/postgres/migrations/20260720100000000_unevaluated-claims-poll-indexes.sql
@@ -1,0 +1,34 @@
+-- Up Migration
+
+-- The subscriptions service polls every few seconds for unevaluated claims
+-- on the claim collections it administers (scoped by the collection's
+-- protocol DID):
+--
+--   claims(filter: {
+--     currentEvaluationId: { isNull: true },
+--     collection: { protocol: { equalTo: $oracleProtocolDid } }
+--   }, orderBy: [SUBMISSION_DATE_ASC], first: N)
+--
+-- "currentEvaluationId IS NULL" alone is NOT selective (mainnet July 2026:
+-- ~34k unevaluated of ~226k claims, mostly other protocols' history), so the
+-- plan must be driven from the collection side: resolve collections by
+-- protocol, then probe per collection for its unevaluated claims. The
+-- partial index below contains ONLY unevaluated claims, keyed exactly for
+-- that probe (+ the submissionDate order the poller asks for), and shrinks
+-- as claims get evaluated. The existing full indexes on Claim can't serve
+-- this cheaply: "Claim_collectionId_submissionDate_idx" scans evaluated
+-- history too, and "Claim_currentEvaluationId_idx" returns the whole
+-- chain-wide unevaluated set with no collection discrimination.
+CREATE INDEX IF NOT EXISTS "Claim_unevaluated_by_collection_idx"
+  ON "Claim"("collectionId", "submissionDate")
+  WHERE "currentEvaluationId" IS NULL;
+
+-- Collections are looked up by protocol DID (the poller's scope filter, and
+-- a natural filter for any "all collections of protocol X" query).
+CREATE INDEX IF NOT EXISTS "ClaimCollection_protocol_idx"
+  ON "ClaimCollection"("protocol");
+
+-- Down Migration
+
+DROP INDEX IF EXISTS "ClaimCollection_protocol_idx";
+DROP INDEX IF EXISTS "Claim_unevaluated_by_collection_idx";


### PR DESCRIPTION
## What

One new migration (`20260720100000000_unevaluated-claims-poll-indexes.sql`) adding two indexes:

- **`Claim_unevaluated_by_collection_idx`** — partial index on `Claim(collectionId, submissionDate) WHERE currentEvaluationId IS NULL`. Contains only unevaluated claims (mainnet: ~34k rows), keyed for per-collection probes with the poller's `SUBMISSION_DATE_ASC` ordering, and shrinks as claims get evaluated.
- **`ClaimCollection_protocol_idx`** — plain index on `ClaimCollection(protocol)`.

## Why

The subscriptions service is replacing its claim-evaluation webhook (`/webhook/claim-submitted` + trusted-DID allowlist) with a cron that polls blocksync-api every ~3s for unevaluated claims on its oracle-services collections:

```graphql
claims(
  filter: {
    currentEvaluationId: { isNull: true }
    collection: { protocol: { equalTo: $oracleProtocolDid } }
  }
  orderBy: [SUBMISSION_DATE_ASC]
  first: 200
)
```

`currentEvaluationId IS NULL` alone is not selective — mainnet has ~34k unevaluated of ~226k claims, almost all belonging to other protocols' history — so the fast plan drives from the collection side: resolve collections by protocol, then probe each collection's unevaluated claims via the partial index.

## Verification

`EXPLAIN (ANALYZE, BUFFERS)` on a mainnet-scale synthetic dataset (226k claims / 32k unevaluated / 2k collections, 30 on the target protocol): the collection-driven nested loop through the new indexes reads **86 buffers (1.7ms)** vs **2,295 buffers (8.7ms)** for the best plan available today (full scan of the chain-wide unevaluated set via `Claim_currentEvaluationId_idx`).

blocksync-api's block-aware response cache additionally bounds the poll to at most one database execution per block, regardless of poll cadence.

## Notes

- Down migration drops both indexes.
- Filename timestamp sorts after `20260715120000000` (develop's latest).
- Plain `CREATE INDEX IF NOT EXISTS` (not `CONCURRENTLY`), matching the existing `query-performance-indexes` migration — the partial index covers ~34k rows, so the build lock is momentary.

Authored by: Michael Pretorius <michael@ixo.world>