### PR TITLE
fix: upgrade bundled npm to v12 to clear node-tar CVE-2026-59873

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ RUN apt-get update \
   && apt-get -y --no-install-recommends install ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
+# The npm bundled with the base image ships a vulnerable node-tar
+# (CVE-2026-59873); npm 12 bundles the fixed tar >=7.5.19.
+RUN npm install -g npm@12 && npm cache clean --force
+
 WORKDIR /usr/src/app
 
 # Install app dependencies


### PR DESCRIPTION
## Summary
The `Build and Release` workflow started failing on both `develop` and `main` with **no dependency changes in the repo** — a newly published CRITICAL CVE tripped the Trivy image scan:

- **CVE-2026-59873** — node-tar gzip bomb DoS, CRITICAL, fixed in tar **7.5.19**
- The vulnerable `tar@7.5.11` is **not an app dependency** (yarn.lock resolves tar to 7.5.15, unaffected); it lives at `/usr/local/lib/node_modules/npm/node_modules/tar` — i.e. inside the npm CLI bundled with the `node:22-bookworm-slim` base image (npm 10.9.8).

## Fix
Add one Dockerfile step upgrading the bundled npm to v12, which bundles tar `^7.5.19`. npm 12 requires Node `^22.22.2`; the base image currently ships 22.23.1, so this is compatible. `npx` stays available for the backfill scripts.

## Verification
Rebuilt the image locally and ran the same gate CI uses:
`trivy image --severity CRITICAL --ignore-unfixed --vuln-type os,library --exit-code 1` → **exit 0** (previously flagged path now clean; npm 12.0.1, tar 7.5.19 confirmed inside the image).

Authored by: Michael Pretorius <michael@ixo.world>

https://claude.ai/code/session_01RNL7V3etUVGfAY6QWSzf7b