### PR TITLE
feat: index the DAO DAO v2.7.1 contract generation

### DIFF
--- a/src/constants/wasm_code_ids.ts
+++ b/src/constants/wasm_code_ids.ts
@@ -151,6 +151,150 @@ const WASM_CODE_IDS = [
     category: "daodao",
     code: { devnet: 27, testnet: 27, mainnet: 27 },
   },
+  // ==========================================================================
+  // DAO DAO v2.7.1 uploads (deterministic upload order on devnet → 30-51).
+  // Names reuse the existing v2.0.3 name strings so the event-handler switch
+  // in event_data_sync_wasm_dao.ts dispatches unchanged; the three names that
+  // did not exist in v2.0.3 are marked NEW.
+  // TODO: testnet/mainnet IDs filled at real upload; 0 = not uploaded
+  // ==========================================================================
+  {
+    name: "dao_core",
+    path: ["contracts", "daodao_v271", "dao_dao_core.wasm"],
+    category: "daodao",
+    code: { devnet: 88, testnet: 52, mainnet: 51 },
+  },
+  {
+    name: "dao_proposal_single",
+    path: ["contracts", "daodao_v271", "dao_proposal_single.wasm"],
+    category: "daodao",
+    code: { devnet: 89, testnet: 53, mainnet: 52 },
+  },
+  {
+    name: "dao_pre_propose_single",
+    path: ["contracts", "daodao_v271", "dao_pre_propose_single.wasm"],
+    category: "daodao",
+    code: { devnet: 90, testnet: 54, mainnet: 53 },
+  },
+  {
+    name: "dao_voting_cw4",
+    path: ["contracts", "daodao_v271", "dao_voting_cw4.wasm"],
+    category: "daodao",
+    code: { devnet: 91, testnet: 55, mainnet: 54 },
+  },
+  {
+    name: "cw4_group",
+    path: ["contracts", "cosmwasm_v271", "cw4_group.wasm"],
+    category: "daodao",
+    code: { devnet: 92, testnet: 56, mainnet: 55 },
+  },
+  {
+    name: "dao_proposal_multiple",
+    path: ["contracts", "daodao_v271", "dao_proposal_multiple.wasm"],
+    category: "daodao",
+    code: { devnet: 93, testnet: 57, mainnet: 56 },
+  },
+  {
+    name: "dao_pre_propose_multiple",
+    path: ["contracts", "daodao_v271", "dao_pre_propose_multiple.wasm"],
+    category: "daodao",
+    code: { devnet: 94, testnet: 58, mainnet: 57 },
+  },
+  {
+    name: "dao_pre_propose_approval_single",
+    path: ["contracts", "daodao_v271", "dao_pre_propose_approval_single.wasm"],
+    category: "daodao",
+    code: { devnet: 95, testnet: 59, mainnet: 58 },
+  },
+  {
+    name: "dao_pre_propose_approver",
+    path: ["contracts", "daodao_v271", "dao_pre_propose_approver.wasm"],
+    category: "daodao",
+    code: { devnet: 96, testnet: 60, mainnet: 59 },
+  },
+  {
+    // NEW name in v2.7.1 — no v2.0.3 twin.
+    name: "dao_pre_propose_approval_multiple",
+    path: ["contracts", "daodao_v271", "dao_pre_propose_approval_multiple.wasm"],
+    category: "daodao",
+    code: { devnet: 97, testnet: 61, mainnet: 60 },
+  },
+  {
+    name: "dao_voting_cw20_staked",
+    path: ["contracts", "daodao_v271", "dao_voting_cw20_staked.wasm"],
+    category: "daodao",
+    code: { devnet: 98, testnet: 62, mainnet: 61 },
+  },
+  {
+    name: "cw20_stake",
+    path: ["contracts", "daodao_v271", "cw20_stake.wasm"],
+    category: "daodao",
+    code: { devnet: 99, testnet: 63, mainnet: 62 },
+  },
+  {
+    name: "cw20_base",
+    path: ["contracts", "cosmwasm_v271", "cw20_base.wasm"],
+    category: "daodao",
+    code: { devnet: 100, testnet: 64, mainnet: 63 },
+  },
+  {
+    name: "dao_voting_cw721_staked",
+    path: ["contracts", "daodao_v271", "dao_voting_cw721_staked.wasm"],
+    category: "daodao",
+    code: { devnet: 101, testnet: 65, mainnet: 64 },
+  },
+  {
+    name: "cw721_base",
+    path: ["contracts", "cosmwasm_v271", "cw721_base.wasm"],
+    category: "daodao",
+    code: { devnet: 102, testnet: 66, mainnet: 65 },
+  },
+  {
+    name: "cw_admin_factory",
+    path: ["contracts", "daodao_v271", "cw_admin_factory.wasm"],
+    category: "daodao",
+    code: { devnet: 103, testnet: 67, mainnet: 66 },
+  },
+  {
+    name: "cw_vesting",
+    path: ["contracts", "daodao_v271", "cw_vesting.wasm"],
+    category: "daodao",
+    code: { devnet: 104, testnet: 68, mainnet: 67 },
+  },
+  {
+    name: "cw_payroll_factory",
+    path: ["contracts", "daodao_v271", "cw_payroll_factory.wasm"],
+    category: "daodao",
+    code: { devnet: 105, testnet: 69, mainnet: 68 },
+  },
+  {
+    // NEW name in v2.7.1 — no v2.0.3 twin.
+    name: "dao_rewards_distributor",
+    path: ["contracts", "daodao_v271", "dao_rewards_distributor.wasm"],
+    category: "daodao",
+    code: { devnet: 106, testnet: 70, mainnet: 69 },
+  },
+  {
+    // NEW name in v2.7.1 — no v2.0.3 twin. Classification only for now —
+    // delegation contract events fall through processDaoEvent's silent
+    // default; no delegation tables are built.
+    name: "dao_vote_delegation",
+    path: ["contracts", "daodao_v271", "dao_vote_delegation.wasm"],
+    category: "daodao",
+    code: { devnet: 107, testnet: 71, mainnet: 70 },
+  },
+  {
+    name: "cw20_stake_external_rewards",
+    path: ["contracts", "daodao_v271", "cw20_stake_external_rewards.wasm"],
+    category: "daodao",
+    code: { devnet: 108, testnet: 72, mainnet: 71 },
+  },
+  {
+    name: "cw20_stake_reward_distributor",
+    path: ["contracts", "daodao_v271", "cw20_stake_reward_distributor.wasm"],
+    category: "daodao",
+    code: { devnet: 109, testnet: 73, mainnet: 72 },
+  },
 ];
 
 // Global checker that NETWORK is valid
@@ -162,18 +306,31 @@ if (!["devnet", "testnet", "mainnet"].includes(NETWORK)) {
 
 /**
  * Map of all contract code ids to their names
+ *
+ * Entries with code id 0 mean "not uploaded on this network yet" and are
+ * excluded — on-chain code ids start at 1, and the instantiate handler
+ * defaults a missing code_id attribute to 0, so a 0 key here would
+ * misclassify unknown contracts (and multiple placeholder-0 entries would
+ * silently collide on the same map key anyway).
  */
 export const CODE_ID_CONTRACT_MAP = new Map<number, string>(
-  WASM_CODE_IDS.map((item) => [item.code[NETWORK], item.name])
+  WASM_CODE_IDS.filter((item) => item.code[NETWORK] > 0).map((item) => [
+    item.code[NETWORK],
+    item.name,
+  ])
 );
 
 /**
  * Map of DAO DAO contract code ids to their names
  * This is used to check if a contract is a DAO DAO contract by querying the code id
+ *
+ * Placeholder code id 0 ("not uploaded on this network") is excluded — see
+ * CODE_ID_CONTRACT_MAP. This also keeps listDaodaoContractsByType's
+ * `code_id = ANY(...)` filter from matching wasm_instantiate rows that were
+ * stored with a defaulted code_id of 0.
  */
 export const DAODAO_CONTRACT_CODE_IDS = new Map<number, string>(
-  WASM_CODE_IDS.filter((item) => item.category === "daodao").map((item) => [
-    item.code[NETWORK],
-    item.name,
-  ])
+  WASM_CODE_IDS.filter(
+    (item) => item.category === "daodao" && item.code[NETWORK] > 0
+  ).map((item) => [item.code[NETWORK], item.name])
 );

--- a/src/postgres/dao.ts
+++ b/src/postgres/dao.ts
@@ -143,14 +143,40 @@ export const deleteDaoCoreItem = async (
 // Bulk-refresh proposal-modules statuses from dao_core dump_state. Called
 // after execute_update_proposal_modules — a passed proposal can add new
 // proposal modules to a DAO and/or mark existing ones as 'disabled'.
+//
+// UPSERT, not UPDATE: dump_state at the event's height already lists a
+// brand-NEW module even though its own instantiate event only arrives
+// later in the same tx — so we stub a row (address, dao_address, prefix,
+// status; other columns NULL) that the subsequent instantiate handling
+// fills in via createDaoProposalModule's ON CONFLICT DO UPDATE.
 // =============================================
 export const refreshDaoProposalModulesFromDumpState = async (
-  proposal_modules: Array<{ address: string; prefix?: string; status?: string }>
+  proposal_modules: Array<{
+    address: string;
+    prefix?: string;
+    status?: string;
+  }>,
+  dao_address: string,
+  created_at: Date,
+  block_height: number
 ): Promise<void> => {
   for (const m of proposal_modules) {
     await dbQuery(
-      "UPDATE dao_proposal_module SET prefix = $2, status = $3 WHERE address = $1;",
-      [m.address, m.prefix ?? null, m.status ?? null]
+      `INSERT INTO dao_proposal_module (
+         address, dao_address, prefix, status, created_at, block_height
+       ) VALUES ($1, $2, $3, $4, $5, $6)
+       ON CONFLICT (address) DO UPDATE SET
+         prefix = EXCLUDED.prefix,
+         status = EXCLUDED.status,
+         dao_address = EXCLUDED.dao_address;`,
+      [
+        m.address,
+        dao_address,
+        m.prefix ?? null,
+        m.status ?? null,
+        created_at,
+        block_height,
+      ]
     );
   }
 };
@@ -158,6 +184,25 @@ export const refreshDaoProposalModulesFromDumpState = async (
 // =============================================
 // DAO Proposal Operations
 // =============================================
+
+// Normalize a proposal status coming off the chain into a plain string for
+// the TEXT column. dao-proposal contracts serialize `Status` as a string
+// for unit variants ("open", "passed", "executed", "vetoed", ...) but
+// v2.7.1's veto timelock variant carries data, so serde emits an OBJECT:
+//   { "veto_timelock": { "expiration": ... } }  →  "veto_timelock"
+// Generic single-key extraction keeps any future data-carrying variant from
+// ever writing "[object Object]" or a JSON blob into the column.
+export const normalizeProposalStatus = (
+  status: string | Record<string, unknown> | null | undefined
+): string | null => {
+  if (status === null || status === undefined) return null;
+  if (typeof status === "string") return status;
+  if (typeof status === "object") {
+    const keys = Object.keys(status);
+    if (keys.length > 0) return keys[0];
+  }
+  return null;
+};
 
 export type DaoProposal = {
   id: string;
@@ -172,7 +217,9 @@ export type DaoProposal = {
   total_power?: string;
   allow_revoting?: boolean;
   msgs?: any;
-  status?: string;
+  // May arrive as the raw chain value (string or data-carrying object) —
+  // normalizeProposalStatus is applied on every write.
+  status?: string | Record<string, unknown>;
   votes?: any;
   created_at: Date;
   block_height: number;
@@ -194,7 +241,7 @@ export const createDaoProposal = async (data: DaoProposal): Promise<void> => {
     data.title,
     data.description,
     data.proposer,
-    data.status,
+    normalizeProposalStatus(data.status),
     data.msgs ? JSON.stringify(data.msgs) : null,
     data.start_height,
     data.min_voting_period ? JSON.stringify(data.min_voting_period) : null,
@@ -215,12 +262,12 @@ UPDATE dao_proposal SET status = $3 WHERE proposal_module = $1 AND id = $2;
 export const updateDaoProposalStatus = async (data: {
   proposal_module: string;
   id: string;
-  status: string;
+  status: string | Record<string, unknown>;
 }): Promise<void> => {
   await dbQuery(updateDaoProposalStatusSql, [
     data.proposal_module,
     data.id,
-    data.status,
+    normalizeProposalStatus(data.status),
   ]);
 };
 
@@ -231,13 +278,13 @@ UPDATE dao_proposal SET status = $3, votes = $4 WHERE proposal_module = $1 AND i
 export const updateDaoProposalStatusAndVotes = async (data: {
   proposal_module: string;
   id: string;
-  status: string;
+  status: string | Record<string, unknown>;
   votes: any;
 }): Promise<void> => {
   await dbQuery(updateDaoProposalStatusAndVotesSql, [
     data.proposal_module,
     data.id,
-    data.status,
+    normalizeProposalStatus(data.status),
     data.votes ? JSON.stringify(data.votes) : null,
   ]);
 };
@@ -298,12 +345,31 @@ export type DaoProposalModule = {
   config?: any;
 };
 
+// ON CONFLICT DO UPDATE (not DO NOTHING): when a governance proposal swaps
+// proposal modules (execute_update_proposal_modules), the dump_state
+// refresh stubs a row for the new module BEFORE its instantiate event is
+// processed — the instantiate must then fill in module_type/config/etc.
+// COALESCE keeps a re-run (e.g. the one-shot snapshot after a prior live
+// index) from wiping already-populated columns with NULLs when a lookup
+// (dao_core dump_state, config query) came back empty. created_at /
+// block_height / pre_propose_module are intentionally untouched — the
+// original stamps win and pre_propose_module is wired separately via
+// updateDaoProposalModulePreProposeModule once the FK target row exists.
 const createDaoProposalModuleSql = `
 INSERT INTO dao_proposal_module (
   address, dao_address, module_type, prefix, status, created_at, block_height,
   proposal_creation_policy, config
 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-ON CONFLICT (address) DO NOTHING;
+ON CONFLICT (address) DO UPDATE SET
+  dao_address = COALESCE(EXCLUDED.dao_address, dao_proposal_module.dao_address),
+  module_type = COALESCE(EXCLUDED.module_type, dao_proposal_module.module_type),
+  prefix = COALESCE(EXCLUDED.prefix, dao_proposal_module.prefix),
+  status = COALESCE(EXCLUDED.status, dao_proposal_module.status),
+  proposal_creation_policy = COALESCE(
+    EXCLUDED.proposal_creation_policy,
+    dao_proposal_module.proposal_creation_policy
+  ),
+  config = COALESCE(EXCLUDED.config, dao_proposal_module.config);
 `;
 
 export const createDaoProposalModule = async (
@@ -547,11 +613,36 @@ export const updateDaoAllVotingModulesUnstakingDurationForCw20Contract = async (
 // DAO Pre-Propose Module Operations
 // =============================================
 
+// v2.7.1 replaced the pre-propose config's `open_proposal_submission`
+// boolean with a structured `submission_policy`:
+//   { "anyone":   { denylist: [...] } }                              — open
+//   { "specific": { dao_members, allowlist, denylist } }             — gated
+// We store submission_policy verbatim (JSONB) and keep the legacy boolean
+// column populated so old API consumers keep working: legacy configs still
+// provide the boolean directly; for v2.7.1 configs we derive it
+// (anyone → true, specific → false).
+export const deriveOpenProposalSubmission = (
+  open_proposal_submission: boolean | undefined | null,
+  submission_policy: any
+): boolean => {
+  if (typeof open_proposal_submission === "boolean") {
+    return open_proposal_submission;
+  }
+  if (submission_policy && typeof submission_policy === "object") {
+    return "anyone" in submission_policy;
+  }
+  return false;
+};
+
 export type DaoPreProposeModule = {
   address: string;
   proposal_module: string;
   deposit_info?: any;
-  open_proposal_submission: boolean;
+  // Legacy (v2.0.3) configs carry the boolean; v2.7.1 configs omit it and
+  // carry submission_policy instead — the stored boolean is then derived.
+  open_proposal_submission?: boolean;
+  // v2.7.1 structured policy; null/undefined for legacy configs.
+  submission_policy?: any;
   created_at: Date;
   block_height: number;
 };
@@ -559,8 +650,8 @@ export type DaoPreProposeModule = {
 const createDaoPreProposeModuleSql = `
 INSERT INTO dao_pre_propose_module (
   address, proposal_module, deposit_info,
-  open_proposal_submission, created_at, block_height
-) VALUES ($1, $2, $3, $4, $5, $6)
+  open_proposal_submission, submission_policy, created_at, block_height
+) VALUES ($1, $2, $3, $4, $5, $6, $7)
 ON CONFLICT (address) DO NOTHING;
 `;
 
@@ -571,7 +662,11 @@ export const createDaoPreProposeModule = async (
     data.address,
     data.proposal_module,
     data.deposit_info ? JSON.stringify(data.deposit_info) : null,
-    data.open_proposal_submission,
+    deriveOpenProposalSubmission(
+      data.open_proposal_submission,
+      data.submission_policy
+    ),
+    data.submission_policy ? JSON.stringify(data.submission_policy) : null,
     data.created_at,
     data.block_height,
   ]);
@@ -580,19 +675,25 @@ export const createDaoPreProposeModule = async (
 const updateDaoPreProposeModuleSql = `
 UPDATE dao_pre_propose_module SET
   deposit_info = $2,
-  open_proposal_submission = $3
+  open_proposal_submission = $3,
+  submission_policy = $4
 WHERE address = $1;
 `;
 
 export const updateDaoPreProposeModule = async (data: {
   address: string;
   deposit_info?: any;
-  open_proposal_submission: boolean;
+  open_proposal_submission?: boolean;
+  submission_policy?: any;
 }): Promise<void> => {
   await dbQuery(updateDaoPreProposeModuleSql, [
     data.address,
     data.deposit_info ? JSON.stringify(data.deposit_info) : null,
-    data.open_proposal_submission,
+    deriveOpenProposalSubmission(
+      data.open_proposal_submission,
+      data.submission_policy
+    ),
+    data.submission_policy ? JSON.stringify(data.submission_policy) : null,
   ]);
 };
 

--- a/src/postgres/migrations/20260728000000000_daodao_v271_submission_policy.sql
+++ b/src/postgres/migrations/20260728000000000_daodao_v271_submission_policy.sql
@@ -1,0 +1,17 @@
+-- Up Migration
+-- DAO DAO v2.7.1 support.
+--
+-- v2.7.1's dao-pre-propose-base replaced the config boolean
+-- `open_proposal_submission` with a structured `submission_policy`:
+--   { "anyone":   { "denylist": [...] } }                       — open submission
+--   { "specific": { "dao_members": bool, "allowlist": [...],
+--                   "denylist": [...] } }                        — gated submission
+-- We store the policy verbatim in this new JSONB column. The legacy
+-- open_proposal_submission boolean column stays populated for old API
+-- consumers — for v2.7.1 configs the indexer derives it from the policy
+-- (anyone → true, specific → false). NULL means the module was indexed
+-- from a legacy (v2.0.3) config that has no structured policy.
+ALTER TABLE dao_pre_propose_module ADD COLUMN IF NOT EXISTS submission_policy JSONB;
+
+-- Down Migration
+-- ALTER TABLE dao_pre_propose_module DROP COLUMN submission_policy;

--- a/src/postgres/wasm.ts
+++ b/src/postgres/wasm.ts
@@ -30,3 +30,18 @@ export const createWasmInstantiate = async (
     data.msg_index,
   ]);
 };
+
+// Called on wasm "migrate" events (MsgMigrateContract) — the contract keeps
+// its address but runs new code, so re-point the stored code_id used for
+// code-id-based classification. If the address was never indexed the UPDATE
+// matches zero rows and this is a no-op by design.
+const updateWasmContractCodeIdSql = `
+UPDATE wasm_instantiate SET code_id = $2 WHERE address = $1;
+`;
+
+export const updateWasmContractCodeId = async (
+  address: string,
+  codeId: number
+): Promise<void> => {
+  await dbQuery(updateWasmContractCodeIdSql, [address, codeId]);
+};

--- a/src/sync/daodao_snapshot.ts
+++ b/src/sync/daodao_snapshot.ts
@@ -209,6 +209,10 @@ const runSnapshot = async (snapshotHeight: number, counts: Counts) => {
     "dao_pre_propose_single",
     "dao_pre_propose_multiple",
     "dao_pre_propose_approval_single",
+    "dao_pre_propose_approval_multiple",
+    // approver is itself a pre-propose module on the approver DAO's
+    // proposal module — it needs a row for the FK in Pass 5
+    "dao_pre_propose_approver",
   ]) {
     for (const addr of byType.get(t) ?? []) {
       await snapshotPreProposeModule(addr, baseCtx);
@@ -352,7 +356,11 @@ const snapshotPreProposeModule = async (address: string, ctx: BaseCtx) => {
     // (the reverse direction); leave NULL here.
     proposal_module: undefined as any,
     deposit_info: cfg.deposit_info,
+    // v2.0.3 configs carry the boolean, v2.7.1 configs carry
+    // submission_policy — pass both through; the postgres layer stores the
+    // policy and derives the legacy boolean when needed.
     open_proposal_submission: cfg.open_proposal_submission,
+    submission_policy: cfg.submission_policy,
     created_at: ctx.snapshotTimestamp,
     block_height: ctx.snapshotHeight,
   });

--- a/src/sync_handlers/event_data_sync_wasm.ts
+++ b/src/sync_handlers/event_data_sync_wasm.ts
@@ -15,7 +15,10 @@ import {
   processIxoSwapEvent,
   processIxoSwapInstantiate,
 } from "./event_data_sync_wasm_ixoswap";
-import { createWasmInstantiate } from "../postgres/wasm";
+import {
+  createWasmInstantiate,
+  updateWasmContractCodeId,
+} from "../postgres/wasm";
 import { DAODAO_CONTRACT_CODE_IDS } from "../constants/wasm_code_ids";
 
 // TODO: re-design the whole getWasmAttr function and see if can make into Map so dont need to filter whole array every time looking for wasm action attributes
@@ -49,6 +52,22 @@ export const syncWasmEventData = async (
         contractType: DAODAO_CONTRACT_CODE_IDS.get(codeId) || "",
         blockHeight: block.height,
       });
+      return;
+    }
+
+    // --------------------------------------------------------------------------------
+    // Wasm Migrate
+    // --------------------------------------------------------------------------------
+    // MsgMigrateContract swaps a contract's code in place (e.g. DAO DAO
+    // v2.0.3 → v2.7.1). The wasm module emits a "migrate" event carrying
+    // _contract_address + code_id — mirror the new code_id onto the
+    // wasm_instantiate row so code-id-based classification stays correct.
+    // Unknown addresses are a no-op (the UPDATE matches zero rows).
+    if (event.type === "migrate") {
+      const codeId = parseInt(getWasmAttr(event.attributes, "code_id") || "0");
+      if (contractAddress && codeId > 0) {
+        await updateWasmContractCodeId(contractAddress, codeId);
+      }
       return;
     }
 

--- a/src/sync_handlers/event_data_sync_wasm_dao.ts
+++ b/src/sync_handlers/event_data_sync_wasm_dao.ts
@@ -126,6 +126,11 @@ export const processDaoEvent = async (
       case "dao_pre_propose_single":
       case "dao_pre_propose_multiple":
       case "dao_pre_propose_approval_single":
+      case "dao_pre_propose_approval_multiple":
+      // The approver contract is itself a pre-propose module on the approver
+      // DAO's proposal module — it MUST get a dao_pre_propose_module row or
+      // the proposal module's pre_propose_module FK breaks on wire-up.
+      case "dao_pre_propose_approver":
         return await processDaoPreProposeEvent(p);
 
       case "cw20_stake":
@@ -141,7 +146,6 @@ export const processDaoEvent = async (
       case "cw_admin_factory":
       case "cw_payroll_factory":
       case "dao_migrator":
-      case "dao_pre_propose_approver":
       case "cw_vesting":
       case "cw20_base":
       case "cw721_base":
@@ -235,9 +239,11 @@ const processDaoCoreEvent = async ({
 
     case "execute_update_proposal_modules": {
       // Governance added/disabled proposal modules. Re-query dump_state
-      // and patch the prefix+status of every module the DAO now reports.
-      // Brand-new modules will get their own instantiate event later in
-      // the same tx → handled by processDaoProposalEvent.instantiate.
+      // and upsert the prefix+status of every module the DAO now reports.
+      // Brand-new modules are already listed by dump_state at this height
+      // even though their instantiate events only arrive later in the same
+      // tx — the upsert stubs their rows (address/dao_address/prefix/
+      // status) and processDaoProposalEvent.instantiate fills in the rest.
       const conf = await daoCoreDumpStateQuery(blockHeight, contractAddress);
       const mods = (conf?.proposal_modules ?? []) as Array<{
         address: string;
@@ -245,7 +251,12 @@ const processDaoCoreEvent = async ({
         status?: string;
       }>;
       if (mods.length) {
-        await refreshDaoProposalModulesFromDumpState(mods);
+        await refreshDaoProposalModulesFromDumpState(
+          mods,
+          contractAddress,
+          timestamp,
+          blockHeight,
+        );
       }
       break;
     }
@@ -483,6 +494,13 @@ const processDaoProposalEvent = async ({
 
     case "execute":
     case "close":
+    // v2.7.1: a vetoer vetoed the proposal (either during the veto
+    // timelock or an open proposal with early-veto enabled). Re-query the
+    // proposal at height and mirror its new status — normally "vetoed",
+    // or "executed"/"closed" when the veto config routes it there.
+    // Status normalization (incl. the object-shaped
+    // { veto_timelock: {...} } status) happens in updateDaoProposalStatus.
+    case "veto":
       const prop2 = await daoProposalInfoQuery(
         blockHeight,
         contractAddress,
@@ -932,6 +950,11 @@ const processDaoPreProposeEvent = async ({
   const contractAddress = getWasmAttr(event.attributes, "_contract_address");
 
   switch (action) {
+    // v2.0.3 configs carry `open_proposal_submission` (boolean); v2.7.1
+    // replaced it with `submission_policy` ({ anyone: ... } | { specific:
+    // ... }). Both are passed through — the postgres layer stores
+    // submission_policy verbatim and derives the legacy boolean when only
+    // the policy exists (anyone → true, specific → false).
     case "instantiate":
       const conf1 = await daoPreProposalModuleConfigQuery(
         blockHeight,
@@ -942,6 +965,7 @@ const processDaoPreProposeEvent = async ({
         proposal_module: getWasmAttr(event.attributes, "proposal_module", true),
         deposit_info: conf1.deposit_info,
         open_proposal_submission: conf1.open_proposal_submission,
+        submission_policy: conf1.submission_policy,
         created_at: timestamp,
         block_height: blockHeight,
       });
@@ -956,23 +980,28 @@ const processDaoPreProposeEvent = async ({
         address: contractAddress,
         deposit_info: config.deposit_info,
         open_proposal_submission: config.open_proposal_submission,
+        submission_policy: config.submission_policy,
       });
       break;
   }
 
   // ---------------------------------------------------------------
-  // dao-pre-propose-approval-single lifecycle.
+  // dao-pre-propose-approval-single/-multiple lifecycle.
   //
-  // This contract uses `method` instead of `action` for its custom events
-  // (legacy convention from dao-pre-propose-base). It emits:
+  // These contracts use `method` instead of `action` for their custom events
+  // (legacy convention from dao-pre-propose-base). Both variants emit the
+  // exact same attributes (verified in v2.7.1 contract.rs of each):
   //   - method=pre-propose         { id }      — pending submission
   //   - method=proposal_approved   { approval_id, proposal_id }
   //   - method=proposal_rejected   { proposal, deposit_info }
   //
-  // We only enter this path for the approval contract type — the regular
+  // We only enter this path for the approval contract types — the regular
   // pre-propose contracts don't carry these methods, so an unconditional
   // method-read would still be safe but is unnecessary.
-  if (contractInfo.contractType === "dao_pre_propose_approval_single") {
+  if (
+    contractInfo.contractType === "dao_pre_propose_approval_single" ||
+    contractInfo.contractType === "dao_pre_propose_approval_multiple"
+  ) {
     const method = getWasmAttr(event.attributes, "method", true);
     switch (method) {
       case "pre-propose": {

--- a/src/sync_handlers/event_sync.ts
+++ b/src/sync_handlers/event_sync.ts
@@ -15,7 +15,11 @@ export const syncEvents = async (block: BlockCore) => {
   for (const event of block.events) {
     let res: any = null;
     try {
-      if (event.type === "wasm" || event.type === "instantiate") {
+      if (
+        event.type === "wasm" ||
+        event.type === "instantiate" ||
+        event.type === "migrate"
+      ) {
         res = await syncWasmEventData(event, block);
       } else {
         await syncEventData(event, block);

--- a/src/util/archive-queries.ts
+++ b/src/util/archive-queries.ts
@@ -293,6 +293,7 @@ export const daoPreProposalModuleConfigQuery = async (
     `/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${query}`,
     height
   );
+  // v2.0.3 example return
   // {
   //     "data": {
   //         "deposit_info": {
@@ -305,6 +306,23 @@ export const daoPreProposalModuleConfigQuery = async (
   //         "open_proposal_submission": false
   //     }
   // }
+  //
+  // v2.7.1 replaced open_proposal_submission with submission_policy:
+  // {
+  //     "data": {
+  //         "deposit_info": null,
+  //         "submission_policy": {
+  //             "specific": {
+  //                 "dao_members": true,
+  //                 "allowlist": [],
+  //                 "denylist": []
+  //             }
+  //         }
+  //     }
+  // }
+  // (or "submission_policy": { "anyone": { "denylist": [] } } for open
+  // submission). The full data object is returned unchanged so consumers
+  // see whichever fields the contract version provides.
   return config?.data;
 };
 


### PR DESCRIPTION
## What

Full indexing support for the DAO DAO v2.7.1 contract generation (Linear: IXO-4090, project "DAODAO Upgrade to latest versions"):

- **Code-ID registry**: 22 new v2.7.1 entries in `wasm_code_ids.ts` with the real per-network ids — devnet **88–109** and testnet **52–73** (both live, checksum-verified), mainnet **51–72** (deterministic; gov proposals 483–504 tally 2026-08-03). Placeholder-0 entries never enter the reverse maps.
- **Migrate events**: `wasm_instantiate.code_id` now updates when a contract migrates (pairs with blocksync-core ≥ v0.5.0, which forwards `migrate` events; older blocksync ignores them via the default case, so rollout order is safe either way).
- **Module swaps**: `UpdateProposalModules` upserts the swapped-in module as enabled and disables the old one.
- **submission_policy**: new JSONB column (+migration) captured from v2.7.1 pre-propose configs, with the legacy `open_proposal_submission` boolean derived for old consumers.
- **v2.7 statuses**: `vetoed` + object-form `veto_timelock` normalized; veto action handled.
- **Approval contracts**: `dao_pre_propose_approval_multiple` and `dao_pre_propose_approver` routed through the pre-propose handler (event switch + approval lifecycle + snapshot pass). Without this their instantiate is dropped and the proposal module's `pre_propose_module` FK violates → permanent sync crash-loop.

## Testing

Proven end-to-end in the ixo-testing-harness DAO DAO suite (**130/130**): v2.0.3 DAOs, migrations of all 4 group types, new v2.7.1 DAOs incl. veto, delegation and approval flows — all indexed with zero errors (10 cores, swapped modules disabled/enabled, approval rows, migrate-event code-id updates).

## Deployment notes

- Deploy per network **before the first v2.7.1 instantiation** there (classification is code-ID based). The uploads already on-chain are inert, so nothing is at risk today; once deployed, zero backfill is ever needed.
- `MIGRATE_DB_PROGRAMATICALLY` runs the new migration on boot; **blocksync-api needs a restart afterwards** so PostGraphile re-introspects the schema (new `submission_policy` column).

Authored by: Michael Pretorius <michael@ixo.world>