### PR TITLE
fix: grant issues/pull-requests write to match shared workflow

### DIFF
--- a/.github/workflows/node-ci-build.yml
+++ b/.github/workflows/node-ci-build.yml
@@ -4,6 +4,8 @@ permissions:
   contents: write
   packages: write
   security-events: write
+  issues: write
+  pull-requests: write
 
 on:
   push:


### PR DESCRIPTION
Every push to main since 2026-07-23 fails at workflow startup (`startup_failure`, zero jobs) — including the v2.7.1 release merge (#162). Root cause: the shared reusable workflow (`ixofoundation/ixo-github-actions/node-ci-build.yml`) gained `issues: write` + `pull-requests: write` on July 23, and a called workflow's permissions may not exceed the caller's explicit grants. Main's caller has had an explicit (now too-narrow) permissions block since July 10; develop has none, which is why develop builds fine.

Two-line fix: extend the caller's block to match the shared workflow. Merging this triggers the release build for the already-merged v2.7.1 indexing changes.

Authored by: Michael Pretorius <michael@ixo.world>