### PR TITLE
feat: event-driven authz grant indexing

### DIFF
--- a/src/postgres/authz.ts
+++ b/src/postgres/authz.ts
@@ -1,0 +1,113 @@
+import { dbQuery } from "./client";
+
+// Active-only authz grant index (see the authz cases in
+// sync_handlers/event_data_sync.ts and the expiry sweep in sync/sync_blocks.ts).
+
+export type AuthzGrantUpsert = {
+  granter: string;
+  grantee: string;
+  msgTypeUrl: string;
+  authorizationType?: string;
+  authorization?: any; // JSON, "@type"-tagged
+  expiration?: Date;
+  entityId?: string;
+  height: number;
+  time: Date;
+  txHash?: string;
+};
+
+// EventGrant/rich-event: create or overwrite the row. A re-grant of the same
+// key overwrites payload and provenance (the chain's SaveGrant is likewise a
+// full overwrite). Payload columns always take the new value - within one tx
+// the bare EventGrant may upsert first and the richer ixo event overwrites
+// with the full payload right after.
+const upsertSql = `
+INSERT INTO authz_grant (
+  granter, grantee, msg_type_url, authorization_type, "authorization",
+  expiration, entity_id, granted_at_height, granted_at_time, granted_tx_hash
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+ON CONFLICT (granter, grantee, msg_type_url) DO UPDATE SET
+  authorization_type = EXCLUDED.authorization_type,
+  "authorization"    = EXCLUDED."authorization",
+  expiration         = EXCLUDED.expiration,
+  entity_id          = EXCLUDED.entity_id,
+  granted_at_height  = EXCLUDED.granted_at_height,
+  granted_at_time    = EXCLUDED.granted_at_time,
+  granted_tx_hash    = EXCLUDED.granted_tx_hash;
+`;
+
+export const upsertAuthzGrant = async (g: AuthzGrantUpsert) => {
+  await dbQuery(upsertSql, [
+    g.granter,
+    g.grantee,
+    g.msgTypeUrl,
+    g.authorizationType ?? null,
+    g.authorization ? JSON.stringify(g.authorization) : null,
+    g.expiration ?? null,
+    g.entityId ?? null,
+    g.height,
+    g.time,
+    g.txHash ?? null,
+  ]);
+};
+
+// EventRevoke: the capability is gone (explicit revoke or exhaustion - the
+// chain emits the same event for both). Row absence IS the record here; the
+// audit trail stays in core's EventCore table.
+const deleteSql = `
+DELETE FROM authz_grant WHERE granter = $1 AND grantee = $2 AND msg_type_url = $3;
+`;
+
+export const deleteAuthzGrant = async (
+  granter: string,
+  grantee: string,
+  msgTypeUrl: string
+) => {
+  await dbQuery(deleteSql, [granter, grantee, msgTypeUrl]);
+};
+
+// Per-block expiry sweep: expiry pruning on-chain is event-silent, so mirror
+// it ourselves. Compares against the indexed block's time (NOT wall clock) so
+// resyncs/backfills expire grants at the historically correct point. Runs
+// inside the per-block transaction; the partial expiration index keeps it a
+// no-op-cost scan on blocks with nothing to expire.
+const expireSql = `
+DELETE FROM authz_grant WHERE expiration IS NOT NULL AND expiration <= $1;
+`;
+
+export const deleteExpiredAuthzGrants = async (blockTime: Date): Promise<number> => {
+  const res = await dbQuery(expireSql, [blockTime]);
+  return res.rowCount ?? 0;
+};
+
+// Constraint-consumption refresh (interim until the chain emits
+// authorization-update events - IXO-4233): overwrites ONLY the payload
+// columns, preserving grant provenance. Returns the affected row count;
+// 0 is legitimate (e.g. an admin acting directly without an authz grant).
+const refreshSql = `
+UPDATE authz_grant SET
+  authorization_type = $4,
+  "authorization"    = $5,
+  expiration         = $6
+WHERE granter = $1 AND grantee = $2 AND msg_type_url = $3;
+`;
+
+export const refreshAuthzGrantPayload = async (
+  granter: string,
+  grantee: string,
+  msgTypeUrl: string,
+  authorizationType: string,
+  authorization: any,
+  expiration?: Date
+): Promise<number> => {
+  const res = await dbQuery(refreshSql, [
+    granter,
+    grantee,
+    msgTypeUrl,
+    authorizationType,
+    JSON.stringify(authorization),
+    expiration ?? null,
+  ]);
+  return res.rowCount ?? 0;
+};

--- a/src/postgres/claim.ts
+++ b/src/postgres/claim.ts
@@ -132,6 +132,18 @@ export const updateClaimCollection = async (
   await dbQuery(upsertClaimCollectionSql, upsertClaimCollectionParams(p));
 };
 
+const getCollectionAdminSql = `
+SELECT "admin" FROM "public"."ClaimCollection" WHERE "id" = $1;
+`;
+// Uses dbQuery so it sees a ClaimCollection created earlier in this same
+// per-block transaction (authz constraint refresh resolves the granter).
+export const getCollectionAdmin = async (
+  id: string
+): Promise<string | undefined> => {
+  const res = await dbQuery(getCollectionAdminSql, [id]);
+  return res.rows[0]?.admin;
+};
+
 export type Claim = {
   claimId: string;
   agentDid: string;

--- a/src/postgres/migrations/20260731000000000_authz_grants_from_events.sql
+++ b/src/postgres/migrations/20260731000000000_authz_grants_from_events.sql
@@ -1,0 +1,48 @@
+-- Up Migration
+
+-- ACTIVE-ONLY index of x/authz grants, driven by the chain's typed events
+-- (cosmos.authz.v1beta1.EventGrant/EventRevoke + the richer
+-- ixo.entity.v1beta1.EntityAccountAuthz*Event), which the SDK emits at KEEPER
+-- level - so every grant path is covered: MsgGrant/MsgRevoke, MsgExec
+-- exhaustion-deletion, ixo entity-account authz (granter = resolved entity
+-- module account, with full authorization + constraints + expiration in the
+-- event), claims module auto-grants, and wasm/ICA/gov-dispatched grants.
+--
+-- Row present = capability currently exists; revocation/exhaustion DELETES
+-- the row (same EventRevoke on-chain), and the per-block expiry sweep in
+-- sync_blocks deletes rows whose expiration <= the indexed block's time (block
+-- time, not wall clock, so historical resyncs expire correctly). The full
+-- audit trail (who granted/revoked what, when) lives in blocksync-core's
+-- EventCore/MessageCore tables - this table is deliberately just the live
+-- capability view, latest constraint state only (the chain emits nothing on
+-- constraint consumption, so no accurate history is possible anyway).
+CREATE TABLE authz_grant (
+    granter TEXT NOT NULL,
+    grantee TEXT NOT NULL,
+    -- msg typeUrl the grant authorizes, e.g. "/cosmos.bank.v1beta1.MsgSend"
+    msg_type_url TEXT NOT NULL,
+    -- @type of the authorization, e.g. "/ixo.claims.v1beta1.SubmitClaimAuthorization";
+    -- NULL when the payload could not be resolved from message or LCD
+    authorization_type TEXT,
+    -- decoded authorization incl. constraints, "@type"-tagged (quoted:
+    -- AUTHORIZATION is a reserved SQL keyword); NULL when unresolvable
+    "authorization" JSONB,
+    -- NULL = never expires
+    expiration TIMESTAMPTZ,
+    -- set when the granter is an ixo entity module account
+    entity_id TEXT,
+    granted_at_height INTEGER NOT NULL,
+    granted_at_time TIMESTAMPTZ NOT NULL,
+    granted_tx_hash TEXT,
+    CONSTRAINT authz_grant_pkey PRIMARY KEY (granter, grantee, msg_type_url)
+);
+
+-- PK covers granter-prefix lookups; add the grantee side, entity lookups and
+-- the expiry-sweep path.
+CREATE INDEX authz_grant_grantee_idx ON authz_grant (grantee);
+CREATE INDEX authz_grant_entity_idx ON authz_grant (entity_id) WHERE entity_id IS NOT NULL;
+CREATE INDEX authz_grant_expiration_idx ON authz_grant (expiration) WHERE expiration IS NOT NULL;
+
+-- Down Migration
+
+DROP TABLE authz_grant;

--- a/src/sync/sync_blocks.ts
+++ b/src/sync/sync_blocks.ts
@@ -1,6 +1,7 @@
 import { sleep } from "../util/sleep";
 import * as TransactionSyncHandler from "../sync_handlers/transaction_sync";
 import * as EventSyncHandler from "../sync_handlers/event_sync";
+import * as AuthzPostgres from "../postgres/authz";
 import { currentChain } from "./sync_chain";
 import { getCoreBlock } from "../postgres/blocksync_core/block";
 import { getChain, updateChain } from "../postgres/chain";
@@ -77,6 +78,11 @@ export const startSync = async () => {
                 blockHeight: block.height,
               }),
             ]);
+
+            // Per-block authz expiry sweep: on-chain expiry pruning emits no
+            // event, so mirror it here against the BLOCK time (not wall
+            // clock) - correct for live sync and historical resyncs alike.
+            await AuthzPostgres.deleteExpiredAuthzGrants(block.time);
           } finally {
             setCurrentPool(undefined);
           }

--- a/src/sync_handlers/event_data_sync.ts
+++ b/src/sync_handlers/event_data_sync.ts
@@ -45,6 +45,7 @@ import {
   upsertMemberBudget,
 } from "../postgres/claim";
 import type { Evaluation } from "../postgres/claim";
+import { getCollectionAdmin } from "../postgres/claim";
 import {
   applyNameStatus,
   applyNameTransfer,
@@ -79,6 +80,18 @@ import {
   removeAuthenticator,
 } from "../postgres/smart_account";
 import { epochStartedOrEnded } from "../postgres/epoch";
+import {
+  deleteAuthzGrant,
+  refreshAuthzGrantPayload,
+  upsertAuthzGrant,
+} from "../postgres/authz";
+import { AUTHZ_CONSTRAINT_REFRESH } from "../util/secrets";
+import {
+  decodeAuthorizationAny,
+  msgTypeUrlForAuthorization,
+  timestampToDate,
+} from "../util/authz";
+import { authzGrantsQuery } from "../util/archive-queries";
 import { smartAccountAuthenticatorQuery } from "../util/archive-queries";
 
 export const syncEventData = async (event: EventCore, block: BlockCore) => {
@@ -221,8 +234,45 @@ export const syncEventData = async (event: EventCore, block: BlockCore) => {
             cClaim.evaluation_history.map((e) => evaluationFromSdk(e, cClaim.claim_id))
           );
         }
+        // authz constraint consumption (agent_quota) is event-silent on
+        // chain - refresh the consumed SubmitClaimAuthorization
+        await refreshConsumedGrant(
+          blockHeight,
+          await getCollectionAdmin(cClaim.collection_id),
+          cClaim.agent_address,
+          "/ixo.claims.v1beta1.MsgSubmitClaim"
+        );
         break;
       }
+      case EventTypes.evaluateClaim: {
+        // evaluations themselves are indexed via ClaimUpdatedEvent; this
+        // event is consumed ONLY to refresh the evaluator's authorization
+        const evaluation: EvaluationSDKType = getDocFromAttributes(
+          event.attributes,
+          event.type
+        );
+        await refreshConsumedGrant(
+          blockHeight,
+          await getCollectionAdmin(evaluation.collection_id),
+          evaluation.agent_address,
+          "/ixo.claims.v1beta1.MsgEvaluateClaim"
+        );
+        break;
+      }
+
+      case EventTypes.claimAuthorizationCreated: {
+        // a creator spending their CreateClaimAuthorizationAuthorization
+        // quota (event-silent); quiet no-op when the collection owner created
+        // the authorization directly (no grant involved)
+        await refreshConsumedGrant(
+          blockHeight,
+          safeGet(event.attributes, "admin"),
+          safeGet(event.attributes, "creator"),
+          "/ixo.claims.v1beta1.MsgCreateClaimAuthorization"
+        );
+        break;
+      }
+
       case EventTypes.updateClaim: {
         const uClaim: ClaimSDKType = getDocFromAttributes(
           event.attributes,
@@ -379,6 +429,147 @@ export const syncEventData = async (event: EventCore, block: BlockCore) => {
         await deleteAgentDepositBalance(
           balance.collection_id,
           balance.agent_address
+        );
+        break;
+      }
+
+      // ==========================================================
+      // AUTHZ (active-only index; row present = capability exists)
+      // ==========================================================
+      case EventTypes.grantAuthz: {
+        const granter = safeGet(event.attributes, "granter");
+        const grantee = safeGet(event.attributes, "grantee");
+        const msgTypeUrl = safeGet(event.attributes, "msg_type_url");
+        const base = {
+          granter,
+          grantee,
+          msgTypeUrl,
+          height: blockHeight,
+          time: block.time,
+          txHash: event.transactionHash,
+        };
+
+        // Claims-module auto-grant (delayed payouts): created with nil
+        // expiration by construction; constraints omitted to avoid per-claim
+        // hydration during claim storms.
+        if (msgTypeUrl === "/ixo.claims.v1beta1.MsgWithdrawPayment") {
+          await upsertAuthzGrant({
+            ...base,
+            authorizationType: "/ixo.claims.v1beta1.WithdrawPaymentAuthorization",
+          });
+          break;
+        }
+
+        // Resolve the payload from the message the event points at (msg_index)
+        const msgIndex = Number(safeGet(event.attributes, "msg_index") || "0");
+        const tx = block.transactions.find(
+          (t) => t.hash === event.transactionHash
+        );
+        const msg = tx?.messages?.[msgIndex];
+
+        if (msg?.typeUrl === "/cosmos.authz.v1beta1.MsgGrant") {
+          const anyAuth = msg.value?.grant?.authorization;
+          const decoded = anyAuth?.typeUrl
+            ? decodeAuthorizationAny(anyAuth)
+            : undefined;
+          await upsertAuthzGrant({
+            ...base,
+            authorizationType: decoded?.type,
+            authorization: decoded?.value,
+            expiration: timestampToDate(msg.value?.grant?.expiration),
+          });
+          break;
+        }
+
+        // Entity-account authz / claim-authorization messages emit the richer
+        // EntityAccountAuthzCreatedEvent in the SAME tx, which carries the
+        // full payload - let that handler write the row.
+        if (
+          msg?.typeUrl === "/ixo.entity.v1beta1.MsgGrantEntityAccountAuthz" ||
+          msg?.typeUrl === "/ixo.claims.v1beta1.MsgCreateClaimAuthorization"
+        ) {
+          break;
+        }
+
+        // Grant dispatched from something we can't read the payload out of
+        // (wasm execute, MsgExec-wrapped grant, ICA, gov): hydrate this pair
+        // from the archive LCD at THIS height (end-of-block state), so
+        // resyncs/backfills store historically correct payloads.
+        try {
+          const live = await authzGrantsQuery(blockHeight, granter, grantee);
+          const match = live.find(
+            (g) =>
+              msgTypeUrlForAuthorization(
+                g.authorization["@type"],
+                g.authorization
+              ) === msgTypeUrl
+          );
+          if (match) {
+            await upsertAuthzGrant({
+              ...base,
+              authorizationType: match.authorization["@type"],
+              authorization: match.authorization,
+              expiration: match.expiration
+                ? new Date(match.expiration)
+                : undefined,
+            });
+            break;
+          }
+        } catch (error) {
+          console.error(
+            `ERROR::grantAuthz hydration (${granter}->${grantee} ${msgTypeUrl}):: `,
+            error.message
+          );
+        }
+        // fall back to a bare row rather than losing the grant
+        await upsertAuthzGrant(base);
+        break;
+      }
+
+      case EventTypes.revokeAuthz: {
+        // Explicit revoke AND exhaustion-deletion (same event on-chain).
+        await deleteAuthzGrant(
+          safeGet(event.attributes, "granter"),
+          safeGet(event.attributes, "grantee"),
+          safeGet(event.attributes, "msg_type_url")
+        );
+        break;
+      }
+
+      case EventTypes.entityAuthzCreated: {
+        // Rich companion to EventGrant: full grant payload + entity DID, with
+        // the granter already resolved to the entity module account.
+        const grant = getValueFromAttributes(event.attributes, "grant");
+        const auth = grant?.authorization;
+        if (!auth?.["@type"]) break;
+        const msgTypeUrl = msgTypeUrlForAuthorization(auth["@type"], auth);
+        if (!msgTypeUrl) {
+          console.warn(
+            `entityAuthzCreated: unmapped authorization type ${auth["@type"]}`
+          );
+          break;
+        }
+        await upsertAuthzGrant({
+          granter: safeGet(event.attributes, "granter"),
+          grantee: safeGet(event.attributes, "grantee"),
+          msgTypeUrl,
+          authorizationType: auth["@type"],
+          authorization: auth,
+          expiration: grant.expiration ? new Date(grant.expiration) : undefined,
+          entityId: safeGet(event.attributes, "id"),
+          height: blockHeight,
+          time: block.time,
+          txHash: event.transactionHash,
+        });
+        break;
+      }
+
+      case EventTypes.entityAuthzRevoked: {
+        // Companion to EventRevoke in the same tx; idempotent double-delete.
+        await deleteAuthzGrant(
+          safeGet(event.attributes, "granter"),
+          safeGet(event.attributes, "grantee"),
+          safeGet(event.attributes, "msg_type_url")
         );
         break;
       }
@@ -910,6 +1101,47 @@ export const syncEventData = async (event: EventCore, block: BlockCore) => {
 // `safeGet` returns the attribute value parsed as JSON when present, or an
 // empty string when missing — avoids throwing inside the switch when an
 // optional field (e.g. `reason` on NameStatusChange) is absent.
+// Interim constraint-consumption refresh (until the chain emits
+// authorization-update events, IXO-4233). The claim events tell us WHICH
+// grant was just consumed; re-fetch that pair's live authorization from the
+// archive LCD at THIS height (end-of-block state, so resyncs stay
+// historically correct) and overwrite the stored payload. Quiet no-ops:
+// grant absent from LCD (this consumption exhausted it - the trailing
+// EventRevoke in the same tx deletes the row) or no row to update (admin
+// acting directly without an authz grant). LCD errors log but do NOT fail
+// the block: existence/exhaustion/expiry stay event-accurate regardless;
+// only constraint freshness degrades until the pair is next touched.
+async function refreshConsumedGrant(
+  height: number,
+  granter: string | undefined,
+  grantee: string | undefined,
+  msgTypeUrl: string
+): Promise<void> {
+  if (!AUTHZ_CONSTRAINT_REFRESH || !granter || !grantee) return;
+  try {
+    const live = await authzGrantsQuery(height, granter, grantee);
+    const match = live.find(
+      (g) =>
+        msgTypeUrlForAuthorization(g.authorization["@type"], g.authorization) ===
+        msgTypeUrl
+    );
+    if (!match) return;
+    await refreshAuthzGrantPayload(
+      granter,
+      grantee,
+      msgTypeUrl,
+      match.authorization["@type"],
+      match.authorization,
+      match.expiration ? new Date(match.expiration) : undefined
+    );
+  } catch (error) {
+    console.error(
+      `ERROR::refreshConsumedGrant (${granter}->${grantee} ${msgTypeUrl}):: `,
+      error.message
+    );
+  }
+}
+
 function safeGet(attributes: any[], key: string): string {
   const attr = attributes.find((a) => a.key === key);
   if (!attr || attr.value == null || attr.value === "") return "";

--- a/src/types/Event.ts
+++ b/src/types/Event.ts
@@ -11,6 +11,10 @@ export enum EventTypes {
   submitClaim = "ixo.claims.v1beta1.ClaimSubmittedEvent",
   updateClaim = "ixo.claims.v1beta1.ClaimUpdatedEvent",
   disputeClaim = "ixo.claims.v1beta1.ClaimDisputedEvent",
+  // consumed ONLY for authz constraint refresh (evaluations themselves are
+  // indexed via ClaimUpdatedEvent)
+  evaluateClaim = "ixo.claims.v1beta1.ClaimEvaluatedEvent",
+  claimAuthorizationCreated = "ixo.claims.v1beta1.ClaimAuthorizationCreatedEvent",
   // claims v7
   disputeResolved = "ixo.claims.v1beta1.DisputeResolvedEvent",
   memberBudgetCreated = "ixo.claims.v1beta1.MemberBudgetCreatedEvent",
@@ -35,6 +39,17 @@ export enum EventTypes {
   lsAddLiquidValidator = "ixo.liquidstake.v1beta1.AddLiquidValidatorEvent",
   lsRebalanced = "ixo.liquidstake.v1beta1.RebalancedLiquidStakeEvent",
   lsAutoCompound = "ixo.liquidstake.v1beta1.AutocompoundStakingRewardsEvent",
+  // authz (cosmos-sdk typed events; keeper-level, so all grant paths emit
+  // them incl. entity-account authz, claims auto-grants and wasm/gov. Flat
+  // scalar attrs (granter/grantee/msg_type_url), read via safeGet - no doc).
+  grantAuthz = "cosmos.authz.v1beta1.EventGrant",
+  revokeAuthz = "cosmos.authz.v1beta1.EventRevoke",
+  // richer ixo companions to EventGrant/EventRevoke for entity-account authz:
+  // carry the FULL grant payload (authorization + constraints + expiration),
+  // the entity DID and the resolved module-account granter. Also emitted by
+  // MsgCreateClaimAuthorization (routes through the same entity msg server).
+  entityAuthzCreated = "ixo.entity.v1beta1.EntityAccountAuthzCreatedEvent",
+  entityAuthzRevoked = "ixo.entity.v1beta1.EntityAccountAuthzRevokedEvent",
   // token
   createToken = "ixo.token.v1beta1.TokenCreatedEvent",
   updateToken = "ixo.token.v1beta1.TokenUpdatedEvent",
@@ -63,6 +78,9 @@ export const EventTypesAttributeKey: { [key in EventTypes]: string } = {
   [EventTypes.submitClaim]: "claim",
   [EventTypes.updateClaim]: "claim",
   [EventTypes.disputeClaim]: "dispute",
+  [EventTypes.evaluateClaim]: "evaluation",
+  // flat scalar attrs, read via safeGet
+  [EventTypes.claimAuthorizationCreated]: "creator",
   // claims v7
   [EventTypes.disputeResolved]: "dispute",
   [EventTypes.memberBudgetCreated]: "budget",
@@ -91,6 +109,12 @@ export const EventTypesAttributeKey: { [key in EventTypes]: string } = {
   [EventTypes.lsAddLiquidValidator]: "validator",
   [EventTypes.lsRebalanced]: "delegator",
   [EventTypes.lsAutoCompound]: "delegator",
+  // authz events emit flat scalar attrs, no wrapped doc - handlers read them
+  // via safeGet; entries below are for completeness only.
+  [EventTypes.grantAuthz]: "granter",
+  [EventTypes.revokeAuthz]: "granter",
+  [EventTypes.entityAuthzCreated]: "grant",
+  [EventTypes.entityAuthzRevoked]: "msg_type_url",
   [EventTypes.createToken]: "token",
   [EventTypes.updateToken]: "token",
   [EventTypes.mintToken]: "tokenProperties",

--- a/src/util/archive-api.ts
+++ b/src/util/archive-api.ts
@@ -82,11 +82,18 @@ const isRetriable500Body = (body: any): boolean => {
 export const queryArchiveApi = async (
   path: string,
   height: number,
+  opts?: { bypassCache?: boolean },
 ): Promise<any> => {
-  cleanupOldHeights(height);
-
-  const cached = archiveApiCache.get(path);
-  if (cached !== undefined) return cached;
+  // bypassCache: neither reads nor writes the height-scoped cache, and does
+  // not advance its height watermark. Needed by callers that query AHEAD of
+  // the block being processed (authz pruned-height snapping) — advancing the
+  // watermark early would let entries cached at the future height be served
+  // to same-path queries at earlier heights.
+  if (!opts?.bypassCache) {
+    cleanupOldHeights(height);
+    const cached = archiveApiCache.get(path);
+    if (cached !== undefined) return cached;
+  }
 
   const url = new URL(path, getBaseUrl()).toString();
 
@@ -99,7 +106,7 @@ export const queryArchiveApi = async (
 
       if (response.ok) {
         const data = await response.json();
-        archiveApiCache.set(path, data);
+        if (!opts?.bypassCache) archiveApiCache.set(path, data);
         return data;
       }
 

--- a/src/util/archive-queries.ts
+++ b/src/util/archive-queries.ts
@@ -778,6 +778,26 @@ export type LcdAuthzGrant = {
   expiration: string | null;
 };
 
+// Some environments' "archive" nodes prune historical state down to every
+// Nth version — testnet retains one in 100 (verified empirically: every
+// multiple-of-100 height serves, everything else returns "failed to load
+// state ... version mismatch on immutable IAVL tree"). When an exact-height
+// authz query hits such a pruned version, retry at the next RETAINED height:
+// exact chain state at most SNAP_INTERVAL-1 blocks later. For the authz
+// payload this is sound — constraints converge to latest-known either way,
+// and a grant that disappears inside the gap is deleted by its own
+// EventRevoke when the sync reaches that block. The snap is authz-only:
+// other archive queries (daodao snapshots etc.) need exact heights.
+const PRUNED_STATE_RE = /failed to load state at height/i;
+const SNAP_INTERVAL = 100;
+// Heights known pruned, so repeated events in the same block skip the
+// doomed exact query. Grows one entry per pruned claim-block — trivial.
+const prunedHeights = new Set<number>();
+// Snapped results keyed granter:grantee, scoped to one snap height at a
+// time (snap heights are non-decreasing while syncing forward).
+let snapCacheHeight = 0;
+const snapCache = new Map<string, LcdAuthzGrant[]>();
+
 // All grants for a (granter, grantee) pair at the given height (end-of-block
 // state). Used only as the hydration fallback for EventGrants whose payload
 // cannot be read from the emitting message (wasm/MsgExec-dispatched grants) —
@@ -787,6 +807,36 @@ export const authzGrantsQuery = async (
   granter: string,
   grantee: string
 ): Promise<LcdAuthzGrant[]> => {
+  const snapped = Math.ceil(height / SNAP_INTERVAL) * SNAP_INTERVAL;
+  if (prunedHeights.has(height)) {
+    return await authzGrantsAt(snapped, granter, grantee, true);
+  }
+  try {
+    return await authzGrantsAt(height, granter, grantee, false);
+  } catch (error: any) {
+    if (snapped === height || !PRUNED_STATE_RE.test(error?.message ?? "")) {
+      throw error;
+    }
+    prunedHeights.add(height);
+    return await authzGrantsAt(snapped, granter, grantee, true);
+  }
+};
+
+const authzGrantsAt = async (
+  height: number,
+  granter: string,
+  grantee: string,
+  isSnap: boolean
+): Promise<LcdAuthzGrant[]> => {
+  const cacheKey = `${granter}:${grantee}`;
+  if (isSnap) {
+    if (height !== snapCacheHeight) {
+      snapCache.clear();
+      snapCacheHeight = height;
+    }
+    const cached = snapCache.get(cacheKey);
+    if (cached !== undefined) return cached;
+  }
   const grants: LcdAuthzGrant[] = [];
   let nextKey: string | undefined = undefined;
   while (true) {
@@ -798,13 +848,16 @@ export const authzGrantsQuery = async (
       (nextKey ? `&pagination.key=${encodeURIComponent(nextKey)}` : "");
     let r: any;
     try {
-      r = await queryArchiveApi(path, height);
+      // the snapped height is AHEAD of the block being processed — bypass
+      // the shared height-scoped cache so its watermark stays consistent
+      // for exact-height consumers (see queryArchiveApi)
+      r = await queryArchiveApi(path, height, { bypassCache: isSnap });
     } catch (error: any) {
       // Some SDK versions answer "no grants for this pair" with a NotFound
       // envelope instead of an empty list. Match the specific authz message
       // only — a broader /not found/ would also match an infra 404 and turn
       // an outage into a silent "no grants".
-      if (/authorization not found/i.test(error?.message ?? "")) return grants;
+      if (/authorization not found/i.test(error?.message ?? "")) break;
       throw error;
     }
     const batch = (r?.grants ?? []) as LcdAuthzGrant[];
@@ -812,5 +865,6 @@ export const authzGrantsQuery = async (
     nextKey = r?.pagination?.next_key ?? undefined;
     if (!nextKey || batch.length === 0) break;
   }
+  if (isSnap) snapCache.set(cacheKey, grants);
   return grants;
 };

--- a/src/util/archive-queries.ts
+++ b/src/util/archive-queries.ts
@@ -769,3 +769,48 @@ export const smartAccountAuthenticatorsQuery = async (
   // }
   return result?.account_authenticators;
 };
+
+// ==========================================================================================
+// Authz
+// ==========================================================================================
+export type LcdAuthzGrant = {
+  authorization: { "@type": string; [key: string]: any };
+  expiration: string | null;
+};
+
+// All grants for a (granter, grantee) pair at the given height (end-of-block
+// state). Used only as the hydration fallback for EventGrants whose payload
+// cannot be read from the emitting message (wasm/MsgExec-dispatched grants) —
+// height-pinned so historical resyncs hydrate historical state.
+export const authzGrantsQuery = async (
+  height: number,
+  granter: string,
+  grantee: string
+): Promise<LcdAuthzGrant[]> => {
+  const grants: LcdAuthzGrant[] = [];
+  let nextKey: string | undefined = undefined;
+  while (true) {
+    const path =
+      `/cosmos/authz/v1beta1/grants` +
+      `?granter=${encodeURIComponent(granter)}` +
+      `&grantee=${encodeURIComponent(grantee)}` +
+      `&pagination.limit=100` +
+      (nextKey ? `&pagination.key=${encodeURIComponent(nextKey)}` : "");
+    let r: any;
+    try {
+      r = await queryArchiveApi(path, height);
+    } catch (error: any) {
+      // Some SDK versions answer "no grants for this pair" with a NotFound
+      // envelope instead of an empty list. Match the specific authz message
+      // only — a broader /not found/ would also match an infra 404 and turn
+      // an outage into a silent "no grants".
+      if (/authorization not found/i.test(error?.message ?? "")) return grants;
+      throw error;
+    }
+    const batch = (r?.grants ?? []) as LcdAuthzGrant[];
+    grants.push(...batch);
+    nextKey = r?.pagination?.next_key ?? undefined;
+    if (!nextKey || batch.length === 0) break;
+  }
+  return grants;
+};

--- a/src/util/authz.ts
+++ b/src/util/authz.ts
@@ -1,0 +1,154 @@
+import { cosmos, cosmwasm, ibc, ixo } from "@ixo/impactxclient-sdk";
+
+// Decode + mapping helpers for event-driven authz indexing
+// (sync_handlers/event_data_sync.ts authz cases).
+
+// Nested protobuf `Any` values inside messages read back from the core DB
+// survive JSON round-tripping in several shapes; normalize them to bytes.
+export const toBytes = (value: any): Uint8Array => {
+  if (value instanceof Uint8Array) return value;
+  if (typeof value === "string")
+    return Uint8Array.from(Buffer.from(value, "base64"));
+  if (Array.isArray(value)) return Uint8Array.from(value);
+  // Node Buffers JSON-serialize as {type:"Buffer",data:[...]}
+  if (value?.type === "Buffer" && Array.isArray(value.data))
+    return Uint8Array.from(value.data);
+  // plain Uint8Arrays JSON-serialize as byte-index objects {"0":10,"1":42,...}
+  return Uint8Array.from(Object.values(value ?? {}) as number[]);
+};
+
+const isLongLike = (v: any): boolean =>
+  v !== null &&
+  typeof v === "object" &&
+  typeof v.low === "number" &&
+  typeof v.high === "number" &&
+  typeof v.unsigned === "boolean";
+
+const longToString = (v: any): string => {
+  const unsigned = BigInt.asUintN(64, (BigInt(v.high) << 32n) | BigInt(v.low >>> 0));
+  return v.unsigned ? unsigned.toString() : BigInt.asIntN(64, unsigned).toString();
+};
+
+// Recursively converts a decoded protobuf object into JSONB-safe values:
+// Long -> string, Uint8Array -> base64, Date -> ISO. {seconds, nanos} objects
+// are deliberately NOT reshaped (Timestamp and Duration are structurally
+// identical; converting blindly would corrupt Duration fields).
+export const sanitizeForJsonb = (value: any): any => {
+  if (value === null || value === undefined) return value;
+  if (value instanceof Uint8Array) return Buffer.from(value).toString("base64");
+  if (value instanceof Date) return value.toISOString();
+  if (isLongLike(value)) return longToString(value);
+  if (Array.isArray(value)) return value.map(sanitizeForJsonb);
+  if (typeof value === "object") {
+    const out: any = {};
+    for (const [k, v] of Object.entries(value)) out[k] = sanitizeForJsonb(v);
+    return out;
+  }
+  return value;
+};
+
+// Grant.expiration in its various shapes (registry-decoded Date serialized to
+// ISO in the core DB, live Date, or a raw {seconds, nanos} Timestamp).
+export const timestampToDate = (ts: any): Date | undefined => {
+  if (!ts) return undefined;
+  if (ts instanceof Date) return ts;
+  if (typeof ts === "string") {
+    const d = new Date(ts);
+    return isNaN(d.getTime()) ? undefined : d;
+  }
+  const seconds = isLongLike(ts.seconds)
+    ? Number(longToString(ts.seconds))
+    : Number(ts.seconds);
+  if (!Number.isFinite(seconds)) return undefined;
+  return new Date(seconds * 1000 + Math.floor(Number(ts.nanos ?? 0) / 1e6));
+};
+
+// Authorization types are mostly not in the SDK's message registry; decode
+// through their generated codecs directly.
+const authorizationCodecs: { [typeUrl: string]: { decode: (b: Uint8Array) => any } } = {
+  "/cosmos.authz.v1beta1.GenericAuthorization": cosmos.authz.v1beta1.GenericAuthorization,
+  "/cosmos.bank.v1beta1.SendAuthorization": cosmos.bank.v1beta1.SendAuthorization,
+  "/cosmos.staking.v1beta1.StakeAuthorization": cosmos.staking.v1beta1.StakeAuthorization,
+  "/cosmwasm.wasm.v1.StoreCodeAuthorization": cosmwasm.wasm.v1.StoreCodeAuthorization,
+  "/cosmwasm.wasm.v1.ContractExecutionAuthorization":
+    cosmwasm.wasm.v1.ContractExecutionAuthorization,
+  "/cosmwasm.wasm.v1.ContractMigrationAuthorization":
+    cosmwasm.wasm.v1.ContractMigrationAuthorization,
+  "/ibc.applications.transfer.v1.TransferAuthorization":
+    ibc.applications.transfer.v1.TransferAuthorization,
+  "/ixo.claims.v1beta1.SubmitClaimAuthorization": ixo.claims.v1beta1.SubmitClaimAuthorization,
+  "/ixo.claims.v1beta1.EvaluateClaimAuthorization": ixo.claims.v1beta1.EvaluateClaimAuthorization,
+  "/ixo.claims.v1beta1.WithdrawPaymentAuthorization":
+    ixo.claims.v1beta1.WithdrawPaymentAuthorization,
+  "/ixo.claims.v1beta1.CreateClaimAuthorizationAuthorization":
+    ixo.claims.v1beta1.CreateClaimAuthorizationAuthorization,
+  "/ixo.token.v1beta1.MintAuthorization": ixo.token.v1beta1.MintAuthorization,
+};
+
+// Decodes an authorization `Any` into "@type"-tagged JSONB-safe JSON
+// (mirrors the LCD / typed-event representation). Unknown types are kept as
+// base64 rather than dropped.
+export const decodeAuthorizationAny = (auth: {
+  typeUrl: string;
+  value: any;
+}): { type: string; value: any } => {
+  const bytes = toBytes(auth.value);
+  const codec = authorizationCodecs[auth.typeUrl];
+  if (!codec) {
+    return {
+      type: auth.typeUrl,
+      value: {
+        "@type": auth.typeUrl,
+        valueBase64: Buffer.from(bytes).toString("base64"),
+        _undecoded: true,
+      },
+    };
+  }
+  return {
+    type: auth.typeUrl,
+    value: { "@type": auth.typeUrl, ...sanitizeForJsonb(codec.decode(bytes)) },
+  };
+};
+
+const stakeAuthzMsgByType: { [k: string]: string } = {
+  AUTHORIZATION_TYPE_DELEGATE: "/cosmos.staking.v1beta1.MsgDelegate",
+  AUTHORIZATION_TYPE_UNDELEGATE: "/cosmos.staking.v1beta1.MsgUndelegate",
+  AUTHORIZATION_TYPE_REDELEGATE: "/cosmos.staking.v1beta1.MsgBeginRedelegate",
+  AUTHORIZATION_TYPE_CANCEL_UNBONDING_DELEGATION:
+    "/cosmos.staking.v1beta1.MsgCancelUnbondingDelegation",
+  "1": "/cosmos.staking.v1beta1.MsgDelegate",
+  "2": "/cosmos.staking.v1beta1.MsgUndelegate",
+  "3": "/cosmos.staking.v1beta1.MsgBeginRedelegate",
+  "4": "/cosmos.staking.v1beta1.MsgCancelUnbondingDelegation",
+};
+
+const fixedMsgTypeByAuthorization: { [typeUrl: string]: string } = {
+  "/cosmos.bank.v1beta1.SendAuthorization": "/cosmos.bank.v1beta1.MsgSend",
+  "/cosmwasm.wasm.v1.StoreCodeAuthorization": "/cosmwasm.wasm.v1.MsgStoreCode",
+  "/cosmwasm.wasm.v1.ContractExecutionAuthorization": "/cosmwasm.wasm.v1.MsgExecuteContract",
+  "/cosmwasm.wasm.v1.ContractMigrationAuthorization": "/cosmwasm.wasm.v1.MsgMigrateContract",
+  "/ibc.applications.transfer.v1.TransferAuthorization":
+    "/ibc.applications.transfer.v1.MsgTransfer",
+  "/ixo.claims.v1beta1.SubmitClaimAuthorization": "/ixo.claims.v1beta1.MsgSubmitClaim",
+  "/ixo.claims.v1beta1.EvaluateClaimAuthorization": "/ixo.claims.v1beta1.MsgEvaluateClaim",
+  "/ixo.claims.v1beta1.WithdrawPaymentAuthorization": "/ixo.claims.v1beta1.MsgWithdrawPayment",
+  "/ixo.claims.v1beta1.CreateClaimAuthorizationAuthorization":
+    "/ixo.claims.v1beta1.MsgCreateClaimAuthorization",
+  "/ixo.token.v1beta1.MintAuthorization": "/ixo.token.v1beta1.MsgMintToken",
+};
+
+// Maps an authorization to the msg typeUrl it authorizes — the third
+// component of the chain's (granter, grantee, msgTypeUrl) grant key. Accepts
+// both LCD/typed-event JSON (snake_case) and proto-decoded (camelCase) shapes.
+export const msgTypeUrlForAuthorization = (
+  authorizationType: string,
+  decoded: any
+): string | undefined => {
+  if (authorizationType === "/cosmos.authz.v1beta1.GenericAuthorization")
+    return decoded?.msg || undefined;
+  if (authorizationType === "/cosmos.staking.v1beta1.StakeAuthorization") {
+    const t = decoded?.authorization_type ?? decoded?.authorizationType;
+    return t === undefined ? undefined : stakeAuthzMsgByType[String(t)];
+  }
+  return fixedMsgTypeByAuthorization[authorizationType];
+};

--- a/src/util/secrets.ts
+++ b/src/util/secrets.ts
@@ -19,5 +19,12 @@ export const NETWORK = process.env.NETWORK || "devnet";
 // is shared by every service, and a pg connection is a whole backend process;
 // small pools that queue briefly under load outperform large ones that
 // stampede the database.
+// Interim (until chain v9 emits authz-update events, IXO-4233): refresh a
+// grant's stored constraints from the archive LCD when claim events show it
+// was consumed. 0 disables; the index then keeps as-granted constraints
+// (existence/exhaustion/expiry stay event-accurate regardless).
+export const AUTHZ_CONSTRAINT_REFRESH =
+  Number(process.env.AUTHZ_CONSTRAINT_REFRESH ?? "1") || 0;
+
 export const DATABASE_POOL_MAX =
   Number(process.env.DATABASE_POOL_MAX ?? "20") || 20;


### PR DESCRIPTION
## What

Adds an **active-only `authz_grant` table** maintained purely from chain events — no per-block message scanning, no unconditional LCD hydration.

- **Sources**: `cosmos.authz.v1beta1.EventGrant`/`EventRevoke` (keeper-level — covers MsgGrant/MsgRevoke, MsgExec exhaustion-deletion, claims auto-grants, wasm/ICA/gov) plus the rich `ixo.entity.v1beta1.EntityAccountAuthzCreated/RevokedEvent` which carry the full grant payload (authorization + constraints + expiration + entity id) for all entity-account paths, including MsgCreateClaimAuthorization.
- **Payload resolution ladder** for bare `EventGrant`: decode the originating message via `msg_index` first; at-height archive LCD as last resort (at-height ⇒ correct during historical reindex).
- **Expiry**: per-block sweep against **block time** inside the block transaction — no cron, backfill-correct.
- **Constraint refresh** (`AUTHZ_CONSTRAINT_REFRESH`, default on): claim submission / evaluation / claim-authorization events re-hydrate the stored payload from at-height LCD, because `keeper.update()` on constraint consumption is event-silent. Interim measure until chain v9 emits update events (IXO-4233), after which this layer is deleted.

Rows are **deleted** on revoke/exhaustion/expiry — the table always reflects currently-active grants with latest-known constraints. Audit history lives in blocksync-core `EventCore`/`MessageCore`.

Depends on blocksync-core v0.6.0 (authz event allowlist) — already deployed to all three environments.

## Testing

Proven end-to-end in the local testing harness: grant via message decode, LCD fallback (MsgExec-wrapped grant), rich entity path with constraints, revoke + exhaustion deletion (EventRevoke at same height as 5th claim), positive expiry sweep, quota refresh 5→4 on claim submission and 100000→99999 on evaluation, zero errors.

## Deployment note

Do **not** merge until the coordinated DB cutover — full blocksync reindex per environment is being prepared locally from rebuilt blocksync-core DBs; this PR merges as part of the devnet cutover.

Authored by: Michael Pretorius <michael@ixo.world>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ixofoundation/codesmith/ixo-blocksync/pr/165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789809869&installation_model_id=432277&pr_number=165&repository=ixofoundation%2Fixo-blocksync&return_to=https%3A%2F%2Fgithub.com%2Fixofoundation%2Fixo-blocksync%2Fpull%2F165&signature=9ae861cb39ce97957f7f623eabbafcbf884ab315945bbb1ccd3e432ca75ed973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->